### PR TITLE
Feature: Integrate Size Recommendation API

### DIFF
--- a/libsource/src/main/java/com/virtusize/libsource/Virtusize.kt
+++ b/libsource/src/main/java/com/virtusize/libsource/Virtusize.kt
@@ -157,12 +157,6 @@ class Virtusize(
                 if (virtusizeView is VirtusizeInPageView) {
                         productCheck.data?.productDataId?.let { productId ->
                             CoroutineScope(Main).launch {
-                                val userBodyProfileResponse = getUserBodyProfileResponse()
-                                Log.d(Constants.INPAGE_LOG_TAG, userBodyProfileResponse.toString())
-                                // TODO: test API endpoints
-                                val userProductResponse = getUserProductsResponse()
-                                Log.d(Constants.INPAGE_LOG_TAG, userProductResponse.toString())
-
                                 if (storeProduct == null) {
                                     val storeProductResponse = getStoreProductResponse(productId)
                                     if (storeProductResponse is VirtusizeApiResponse.Success) {
@@ -175,6 +169,8 @@ class Virtusize(
                                         return@launch
                                     }
                                 }
+                                val userBodyRecommendedSize = getUserBodyRecommendedSize()
+                                Log.d(Constants.INPAGE_LOG_TAG, userBodyRecommendedSize.toString())
                                 val i18nResponse = getI18nResponse()
                                 if (i18nResponse is VirtusizeApiResponse.Success && i18nResponse.data != null) {
                                     val trimType = if (virtusizeView is VirtusizeInPageStandard) TrimType.MULTIPLELINES else TrimType.ONELINE
@@ -246,6 +242,29 @@ class Virtusize(
         } else {
             productValidCheckListener.onValidProductCheckCompleted(productCheckData!!)
         }
+    }
+
+    /**
+     * Gets size recommendation for a store product that would best fit a user's body.
+     * @return recommended size name. If it's not available, return null
+     */
+    private suspend fun getUserBodyRecommendedSize(): String? {
+        if(storeProduct!!.isAccessory()) {
+            return null
+        }
+        val userBodyProfileResponse = getUserBodyProfileResponse()
+        val productTypesResponse = getProductTypesResponse()
+        if (productTypesResponse is VirtusizeApiResponse.Success && userBodyProfileResponse is VirtusizeApiResponse.Success) {
+            val bodyProfileRecommendedSizeResponse = getBodyProfileRecommendedSizeResponse(
+                productTypesResponse.data,
+                storeProduct!!,
+                userBodyProfileResponse.data
+            )
+            if (bodyProfileRecommendedSizeResponse is VirtusizeApiResponse.Success) {
+                return bodyProfileRecommendedSizeResponse.data?.sizeName
+            }
+        }
+        return null
     }
 
     /**
@@ -439,30 +458,14 @@ class Virtusize(
     }
 
     /**
-     * Retrieves the list of the product types
-     * @param onSuccess the optional success callback to pass the list of [ProductType]
-     * @param onError the optional error callback to get the [VirtusizeError] in the API task
+     * Gets the API response for retrieving the list of the product types
      */
-    internal fun getProductTypes(
-        onSuccess: ((List<ProductType>?) -> Unit)? = null,
-        onError: ((VirtusizeError) -> Unit)? = null
-    ) {
+    internal suspend fun getProductTypesResponse(): VirtusizeApiResponse<List<ProductType>?> = withContext(IO) {
         val apiRequest = VirtusizeApi.getProductTypes()
-        VirtusizeApiTask()
+        return@withContext VirtusizeApiTask()
             .setJsonParser(ProductTypeJsonParser())
-            .setSuccessHandler(object : SuccessResponseHandler {
-                override fun onSuccess(data: Any?) {
-                    onSuccess?.invoke(data as? List<ProductType>)
-                }
-            })
-            .setErrorHandler(object : ErrorResponseHandler {
-                override fun onError(error: VirtusizeError) {
-                    onError?.invoke(error)
-                }
-            })
             .setHttpURLConnection(httpURLConnection)
-            .setCoroutineDispatcher(coroutineDispatcher)
-            .executeAsync(apiRequest)
+            .execute(apiRequest) as VirtusizeApiResponse<List<ProductType>?>
     }
 
     /**
@@ -493,12 +496,23 @@ class Virtusize(
      * Gets the API response for retrieving the current user body profile such as age, height, weight and body measurements
      * @return the [VirtusizeApiResponse] with the data class [UserBodyProfile]
      */
-    internal suspend fun getUserBodyProfileResponse(): VirtusizeApiResponse<UserBodyProfile?>? = withContext(IO) {
+    internal suspend fun getUserBodyProfileResponse(): VirtusizeApiResponse<UserBodyProfile?> = withContext(IO) {
         val apiRequest = VirtusizeApi.getUserBodyProfile()
         VirtusizeApiTask()
             .setJsonParser(UserBodyProfileJsonParser())
             .setHttpURLConnection(httpURLConnection)
-            .execute(apiRequest) as? VirtusizeApiResponse<UserBodyProfile?>
+            .execute(apiRequest) as VirtusizeApiResponse<UserBodyProfile?>
+    }
+
+    internal suspend fun getBodyProfileRecommendedSizeResponse(productTypes: List<ProductType>?, storeProduct: Product, userBodyProfile: UserBodyProfile?): VirtusizeApiResponse<BodyProfileRecommendedSize?> = withContext(IO) {
+        if(productTypes == null || userBodyProfile == null) {
+            return@withContext VirtusizeApiResponse.Success(null)
+        }
+        val apiRequest = VirtusizeApi.getSize(productTypes, storeProduct, userBodyProfile)
+        VirtusizeApiTask()
+            .setJsonParser(BodyProfileRecommendedSizeJsonParser())
+            .setHttpURLConnection(httpURLConnection)
+            .execute(apiRequest) as VirtusizeApiResponse<BodyProfileRecommendedSize?>
     }
 
     /**

--- a/libsource/src/main/java/com/virtusize/libsource/data/local/BodyProfileRecommendedSizeParams.kt
+++ b/libsource/src/main/java/com/virtusize/libsource/data/local/BodyProfileRecommendedSizeParams.kt
@@ -1,10 +1,13 @@
 package com.virtusize.libsource.data.local
 
 import com.virtusize.libsource.data.remote.Product
+import com.virtusize.libsource.data.remote.ProductType
 import com.virtusize.libsource.data.remote.UserBodyProfile
 import org.json.JSONObject
 
+// TODO: add comment
 internal data class BodyProfileRecommendedSizeParams constructor(
+    private val productTypes: List<ProductType>,
     private val storeProduct: Product,
     private val userBodyProfile: UserBodyProfile
 ) {
@@ -12,6 +15,18 @@ internal data class BodyProfileRecommendedSizeParams constructor(
         return emptyMap<String, Any>()
             .plus(
                 mapOf(PARAM_ADDITIONAL_INFO to createAdditionalInfoParams() )
+            )
+            .plus(
+                mapOf(PARAM_BODY_DATA to createBodyDataParams())
+            )
+            .plus(
+                mapOf(PARAM_ITEM_SIZES to createItemSizesParams())
+            )
+            .plus(
+                mapOf(PARAM_PRODUCT_TYPE to (productTypes.find { it.id == storeProduct.productType }?.name ?: ""))
+            )
+            .plus(
+                mapOf(PARAM_USER_GENDER to (userBodyProfile.gender ?: ""))
             )
     }
 
@@ -22,7 +37,7 @@ internal data class BodyProfileRecommendedSizeParams constructor(
                 measurement.name to measurement.millimeter
             }.toMap()
         }?.toMap()
-        val gender = storeProduct.storeProductMeta?.gender // storeProduct.storeProductMeta?.additionalInfo?.gender ?:
+        val gender = storeProduct.storeProductMeta?.additionalInfo?.gender ?: storeProduct.storeProductMeta?.gender
         return emptyMap<String, Any?>()
             .plus(
                 mapOf(PARAM_BRAND to (brand ?: ""))
@@ -41,12 +56,49 @@ internal data class BodyProfileRecommendedSizeParams constructor(
             )
     }
 
+    fun createBodyDataParams(): Map<String, Any?> {
+        var chestValue: Int? = null
+        return emptyMap<String, Any?>()
+            .plus(
+                userBodyProfile.bodyData.map {
+                    if(it.name == PARAM_BODY_BUST) {
+                        chestValue = it.millimeter
+                    }
+                    it.name to mutableMapOf(PARAM_BODY_MEASUREMENT_VALUE to it.millimeter, PARAM_BODY_MEASUREMENT_PREDICTED to true)
+                }
+            )
+            .plus(
+                chestValue?.let { mapOf(PARAM_BODY_CHEST to mutableMapOf(PARAM_BODY_MEASUREMENT_VALUE to it, PARAM_BODY_MEASUREMENT_PREDICTED to true))}.orEmpty()
+            )
+    }
+
+    fun createItemSizesParams(): Map<String, Any?> {
+        return emptyMap<String, Any?>()
+            .plus(
+                storeProduct.sizes.map { productSize ->
+                    productSize.name to productSize.measurements.map { measurement ->
+                        measurement.name to measurement.millimeter
+                    }.toMap()
+                }
+            )
+    }
+
     private companion object {
         const val PARAM_ADDITIONAL_INFO = "additional_info"
+        const val PARAM_BODY_DATA = "body_data"
+        const val PARAM_ITEM_SIZES = "item_sizes_orig"
+        const val PARAM_PRODUCT_TYPE = "product_type"
+        const val PARAM_USER_GENDER = "user_gender"
+
         const val PARAM_BRAND = "brand"
         const val PARAM_FIT = "fit"
         const val PARAM_SIZES = "sizes"
         const val PARAM_MODEL_INFO = "model_info"
         const val PARAM_GENDER = "gender"
+
+        const val PARAM_BODY_MEASUREMENT_VALUE = "value"
+        const val PARAM_BODY_MEASUREMENT_PREDICTED = "predicted"
+        const val PARAM_BODY_BUST = "bust"
+        const val PARAM_BODY_CHEST = "chest"
     }
 }

--- a/libsource/src/main/java/com/virtusize/libsource/data/local/BodyProfileRecommendedSizeParams.kt
+++ b/libsource/src/main/java/com/virtusize/libsource/data/local/BodyProfileRecommendedSizeParams.kt
@@ -1,0 +1,52 @@
+package com.virtusize.libsource.data.local
+
+import com.virtusize.libsource.data.remote.Product
+import com.virtusize.libsource.data.remote.UserBodyProfile
+import org.json.JSONObject
+
+internal data class BodyProfileRecommendedSizeParams constructor(
+    private val storeProduct: Product,
+    private val userBodyProfile: UserBodyProfile
+) {
+    fun paramsToMap(): Map<String, Any> {
+        return emptyMap<String, Any>()
+            .plus(
+                mapOf(PARAM_ADDITIONAL_INFO to createAdditionalInfoParams() )
+            )
+    }
+
+    fun createAdditionalInfoParams(): Map<String, Any?> {
+        val brand = storeProduct.storeProductMeta?.additionalInfo?.brand ?: storeProduct.storeProductMeta?.brand
+        val sizeHashMap = storeProduct.storeProductMeta?.additionalInfo?.sizes?.map {
+            it.name to it.measurements.map { measurement ->
+                measurement.name to measurement.millimeter
+            }.toMap()
+        }?.toMap()
+        val gender = storeProduct.storeProductMeta?.gender // storeProduct.storeProductMeta?.additionalInfo?.gender ?:
+        return emptyMap<String, Any?>()
+            .plus(
+                mapOf(PARAM_BRAND to (brand ?: ""))
+            )
+            .plus(
+                mapOf(PARAM_FIT to (storeProduct.storeProductMeta?.additionalInfo?.fit ?: "regular"))
+            )
+            .plus(
+                mapOf(PARAM_SIZES to (sizeHashMap ?: "{}"))
+            )
+            .plus(
+                mapOf(PARAM_MODEL_INFO to (storeProduct.storeProductMeta?.additionalInfo?.modelInfo ?: "{}"))
+            )
+            .plus(
+                mapOf(PARAM_GENDER to (gender ?: JSONObject.NULL))
+            )
+    }
+
+    private companion object {
+        const val PARAM_ADDITIONAL_INFO = "additional_info"
+        const val PARAM_BRAND = "brand"
+        const val PARAM_FIT = "fit"
+        const val PARAM_SIZES = "sizes"
+        const val PARAM_MODEL_INFO = "model_info"
+        const val PARAM_GENDER = "gender"
+    }
+}

--- a/libsource/src/main/java/com/virtusize/libsource/data/local/BodyProfileRecommendedSizeParams.kt
+++ b/libsource/src/main/java/com/virtusize/libsource/data/local/BodyProfileRecommendedSizeParams.kt
@@ -46,10 +46,10 @@ internal data class BodyProfileRecommendedSizeParams constructor(
                 mapOf(PARAM_FIT to (storeProduct.storeProductMeta?.additionalInfo?.fit ?: "regular"))
             )
             .plus(
-                mapOf(PARAM_SIZES to (sizeHashMap ?: "{}"))
+                mapOf(PARAM_SIZES to (sizeHashMap ?: mutableMapOf()))
             )
             .plus(
-                mapOf(PARAM_MODEL_INFO to (storeProduct.storeProductMeta?.additionalInfo?.modelInfo ?: "{}"))
+                mapOf(PARAM_MODEL_INFO to (storeProduct.storeProductMeta?.additionalInfo?.modelInfo ?: mutableMapOf()))
             )
             .plus(
                 mapOf(PARAM_GENDER to (gender ?: JSONObject.NULL))

--- a/libsource/src/main/java/com/virtusize/libsource/data/local/VirtusizeEnvironment.kt
+++ b/libsource/src/main/java/com/virtusize/libsource/data/local/VirtusizeEnvironment.kt
@@ -13,10 +13,10 @@ enum class VirtusizeEnvironment {
 }
 
 /**
- * Gets the API URL corresponding to the Virtusize Environment
- * @return A String value of the API URL
+ * Gets the default API URL corresponding to the Virtusize Environment
+ * @return A String value of the default API URL
  */
-fun VirtusizeEnvironment.apiUrl(): String {
+fun VirtusizeEnvironment.defaultApiUrl(): String {
     return when(this) {
         STAGING -> "https://staging.virtusize.com"
         GLOBAL -> "https://api.virtusize.com"
@@ -26,10 +26,10 @@ fun VirtusizeEnvironment.apiUrl(): String {
 }
 
 /**
- * Gets the URL for the API endpoint Product Data Check corresponding to the Virtusize Environment
- * @return A String value of the URL for the API endpoint Product Data Check
+ * Gets the services API URL corresponding to the Virtusize Environment
+ * @return A String value of the services API URL
  */
-fun VirtusizeEnvironment.productDataCheckUrl(): String {
+fun VirtusizeEnvironment.servicesApiUrl(): String {
     return when(this) {
         STAGING -> "https://services.virtusize.com/stg"
         else -> "https://services.virtusize.com/"

--- a/libsource/src/main/java/com/virtusize/libsource/data/parsers/BodyProfileRecommendedSizeJsonParser.kt
+++ b/libsource/src/main/java/com/virtusize/libsource/data/parsers/BodyProfileRecommendedSizeJsonParser.kt
@@ -1,0 +1,17 @@
+package com.virtusize.libsource.data.parsers
+
+import com.virtusize.libsource.data.remote.BodyProfileRecommendedSize
+import org.json.JSONObject
+
+// TODO: add comment
+class BodyProfileRecommendedSizeJsonParser : VirtusizeJsonParser<BodyProfileRecommendedSize> {
+
+    override fun parse(json: JSONObject): BodyProfileRecommendedSize? {
+        val sizeName = json.getString(FIELD_NAME)
+        return BodyProfileRecommendedSize(sizeName)
+    }
+
+    private companion object {
+        const val FIELD_NAME = "sizeName"
+    }
+}

--- a/libsource/src/main/java/com/virtusize/libsource/data/parsers/JsonUtils.kt
+++ b/libsource/src/main/java/com/virtusize/libsource/data/parsers/JsonUtils.kt
@@ -19,8 +19,20 @@ internal object JsonUtils {
      * @return the value stored in the field. If it isn't present, it returns an empty string
      */
     internal fun optString(jsonObject: JSONObject, name: String?): String {
+        val stringValue = optNullableString(jsonObject, name)
+        return stringValue ?: ""
+    }
+
+    /**
+     * Returns the String value mapped by name. If it isn't present, return null
+     *
+     * @param jsonObject the input JSON object
+     * @param name the optional field name
+     * @return the value stored in the field. If it isn't present, it returns null
+     */
+    internal fun optNullableString(jsonObject: JSONObject, name: String?): String? {
         val stringValue = jsonObject.optString(name)
-        return if(stringValue == "null") "" else stringValue
+        return if(stringValue == "null") null else stringValue
     }
 
     /**
@@ -29,7 +41,7 @@ internal object JsonUtils {
      * @param jsonObject a JSONObject to be converted
      * @return a Map representing the input
      */
-    internal fun jsonObjectToMap(jsonObject: JSONObject): Map<String, Any> {
+    internal fun jsonObjectToMap(jsonObject: JSONObject): MutableMap<String, Any> {
         val map: MutableMap<String, Any> = HashMap()
         val keys: Iterator<String> = jsonObject.keys()
         while (keys.hasNext()) {

--- a/libsource/src/main/java/com/virtusize/libsource/data/parsers/StoreProductAdditionalInfoJsonParser.kt
+++ b/libsource/src/main/java/com/virtusize/libsource/data/parsers/StoreProductAdditionalInfoJsonParser.kt
@@ -1,6 +1,8 @@
 package com.virtusize.libsource.data.parsers
 
 import com.virtusize.libsource.data.remote.BrandSizing
+import com.virtusize.libsource.data.remote.Measurement
+import com.virtusize.libsource.data.remote.ProductSize
 import com.virtusize.libsource.data.remote.StoreProductAdditionalInfo
 import org.json.JSONObject
 
@@ -9,6 +11,24 @@ import org.json.JSONObject
  */
 class StoreProductAdditionalInfoJsonParser : VirtusizeJsonParser<StoreProductAdditionalInfo> {
     override fun parse(json: JSONObject): StoreProductAdditionalInfo? {
+        val brand = JsonUtils.optString(json, FIELD_BRAND)
+        val gender = JsonUtils.optNullableString(json, FIELD_GENDER)
+        var sizes = setOf<ProductSize>()
+        json.optJSONObject(FIELD_SIZES)?.let { jsonObject ->
+            sizes = JsonUtils.jsonObjectToMap(jsonObject)
+                .map { filteredSizeHashMap ->
+                    ProductSize(
+                        filteredSizeHashMap.key, (filteredSizeHashMap.value as MutableMap<String, Int>)
+                            .map {
+                                Measurement(it.key, it.value)
+                            }.toMutableSet()
+                    )
+                }.toMutableSet()
+        }
+        var modelInfo =  mutableMapOf<String, Any>()
+        json.optJSONObject(FIELD_MODEL_INFO)?.let {
+            modelInfo = JsonUtils.jsonObjectToMap(it)
+        }
         val fit = JsonUtils.optString(json, FIELD_FIT)
         val style = JsonUtils.optString(json, FIELD_STYLE)
         var brandSizing: BrandSizing? = null
@@ -18,12 +38,16 @@ class StoreProductAdditionalInfoJsonParser : VirtusizeJsonParser<StoreProductAdd
         if(fit.isBlank() && brandSizing == null) {
             return null
         }
-        return StoreProductAdditionalInfo(fit, style, brandSizing)
+        return StoreProductAdditionalInfo(brand, gender, sizes, modelInfo, fit, style, brandSizing)
     }
 
-    companion object {
-        private const val FIELD_FIT = "fit"
-        private const val FIELD_STYLE = "style"
-        private const val FIELD_BRAND_SIZING = "brandSizing"
+    private companion object {
+        const val FIELD_BRAND = "brand"
+        const val FIELD_GENDER = "gender"
+        const val FIELD_SIZES = "sizes"
+        const val FIELD_MODEL_INFO = "modelInfo"
+        const val FIELD_FIT = "fit"
+        const val FIELD_STYLE = "style"
+        const val FIELD_BRAND_SIZING = "brandSizing"
     }
 }

--- a/libsource/src/main/java/com/virtusize/libsource/data/parsers/StoreProductMetaJsonParser.kt
+++ b/libsource/src/main/java/com/virtusize/libsource/data/parsers/StoreProductMetaJsonParser.kt
@@ -1,5 +1,6 @@
 package com.virtusize.libsource.data.parsers
 
+import com.virtusize.libsource.data.local.VirtusizeOrderItem
 import com.virtusize.libsource.data.remote.StoreProductAdditionalInfo
 import com.virtusize.libsource.data.remote.StoreProductMeta
 import org.json.JSONObject
@@ -14,14 +15,18 @@ internal class StoreProductMetaJsonParser: VirtusizeJsonParser<StoreProductMeta>
         json.optJSONObject(FIELD_ADDITIONAL_INFO)?.let {
             additionalInfo = StoreProductAdditionalInfoJsonParser().parse(it)
         }
+        val brand = json.optString(FIELD_BRAND)
+        val gender = JsonUtils.optNullableString(json, FIELD_GENDER)
         if (id == 0) {
             return null
         }
-       return StoreProductMeta(id, additionalInfo)
+        return StoreProductMeta(id, additionalInfo, brand, gender)
     }
 
-    companion object {
-        private const val FIELD_ID = "id"
-        private const val FIELD_ADDITIONAL_INFO = "additionalInfo"
+    private companion object {
+        const val FIELD_ID = "id"
+        const val FIELD_ADDITIONAL_INFO = "additionalInfo"
+        const val FIELD_BRAND = "brand"
+        const val FIELD_GENDER = "gender"
     }
 }

--- a/libsource/src/main/java/com/virtusize/libsource/data/remote/BodyProfileRecommendedSize.kt
+++ b/libsource/src/main/java/com/virtusize/libsource/data/remote/BodyProfileRecommendedSize.kt
@@ -1,0 +1,6 @@
+package com.virtusize.libsource.data.remote
+
+// TODO: add comment
+data class BodyProfileRecommendedSize(
+    val sizeName: String
+)

--- a/libsource/src/main/java/com/virtusize/libsource/data/remote/Product.kt
+++ b/libsource/src/main/java/com/virtusize/libsource/data/remote/Product.kt
@@ -44,7 +44,7 @@ data class Product(
      *
      * Note: 18 is for bags, 19 is for clutches, 25 is for wallets and 26 is for props
      */
-    private fun isAccessory(): Boolean {
+    internal fun isAccessory(): Boolean {
         return productType == 18 || productType == 19 || productType == 25 || productType == 26
     }
 }

--- a/libsource/src/main/java/com/virtusize/libsource/data/remote/StoreProductAdditionalInfo.kt
+++ b/libsource/src/main/java/com/virtusize/libsource/data/remote/StoreProductAdditionalInfo.kt
@@ -4,11 +4,21 @@ import com.virtusize.libsource.util.I18nConstants
 
 /**
  * This class represents the additional info of a store product
+ * @param brand the brand name
+ * @param gender the gender for the product
+ * @param sizes the size list of the product
+ * @param modelInfo the model info
  * @param fit the general fit key
+ * @param style the store product style
  * @param brandSizing the brand sizing info
+ * @see ProductSize
  * @see BrandSizing
  */
 data class StoreProductAdditionalInfo(
+    val brand: String,
+    val gender: String?,
+    val sizes: Set<ProductSize>,
+    val modelInfo: Map<String, Any>?,
     val fit: String?,
     val style: String?,
     val brandSizing: BrandSizing?

--- a/libsource/src/main/java/com/virtusize/libsource/data/remote/StoreProductMeta.kt
+++ b/libsource/src/main/java/com/virtusize/libsource/data/remote/StoreProductMeta.kt
@@ -4,9 +4,13 @@ package com.virtusize.libsource.data.remote
  * This class represents the meta data of a store product
  * @param id the ID of the store product meta
  * @param additionalInfo the additional info of a store product
+ * @param brand the brand name
+ * @param gender the gender for the product
  * @see StoreProductAdditionalInfo
  */
 data class StoreProductMeta(
     val id: Int,
-    val additionalInfo: StoreProductAdditionalInfo?
+    val additionalInfo: StoreProductAdditionalInfo?,
+    val brand: String,
+    val gender: String?
 )

--- a/libsource/src/main/java/com/virtusize/libsource/data/remote/UserBodyProfile.kt
+++ b/libsource/src/main/java/com/virtusize/libsource/data/remote/UserBodyProfile.kt
@@ -1,7 +1,8 @@
 package com.virtusize.libsource.data.remote
 
+// TODO: add comment
 data class UserBodyProfile(
-    val gender: String?,
+    val gender: String,
     val age: Int,
     val height: Int,
     val weight: String,

--- a/libsource/src/main/java/com/virtusize/libsource/network/VirtusizeApi.kt
+++ b/libsource/src/main/java/com/virtusize/libsource/network/VirtusizeApi.kt
@@ -3,7 +3,10 @@ package com.virtusize.libsource.network
 import android.net.Uri
 import com.virtusize.libsource.data.local.*
 import com.virtusize.libsource.data.parsers.JsonUtils
+import com.virtusize.libsource.data.remote.Product
 import com.virtusize.libsource.data.remote.ProductCheck
+import com.virtusize.libsource.data.remote.ProductType
+import com.virtusize.libsource.data.remote.UserBodyProfile
 
 
 /**
@@ -21,7 +24,7 @@ internal enum class HttpMethod {
  * @param params the MutableMap of query parameters to be sent to the server
  * @param authorization if it's true, it means you need the auth token to make the API request
  */
-internal data class ApiRequest(val url: String, val method: HttpMethod, val params: MutableMap<String, Any> = mutableMapOf(), val authorization: Boolean = false)
+internal data class ApiRequest(val url: String, val method: HttpMethod, val params: Map<String, Any> = mutableMapOf(), val authorization: Boolean = false)
 
 /**
  * This object represents the Virtusize API
@@ -57,7 +60,7 @@ internal object VirtusizeApi {
      * @see ApiRequest
      */
     fun productCheck(product: VirtusizeProduct): ApiRequest {
-        val urlBuilder = Uri.parse(environment.productDataCheckUrl() + VirtusizeEndpoint.ProductCheck.getPath())
+        val urlBuilder = Uri.parse(environment.servicesApiUrl() + VirtusizeEndpoint.ProductCheck.getPath())
             .buildUpon()
             .appendQueryParameter("apiKey", apiKey)
             .appendQueryParameter("externalId", product.externalId)
@@ -82,7 +85,7 @@ internal object VirtusizeApi {
      * @return ApiRequest
      */
     fun sendProductImageToBackend(product: VirtusizeProduct): ApiRequest {
-        val url = Uri.parse(environment.apiUrl() + VirtusizeEndpoint.ProductMetaDataHints.getPath())
+        val url = Uri.parse(environment.defaultApiUrl() + VirtusizeEndpoint.ProductMetaDataHints.getPath())
             .buildUpon()
             .build()
             .toString()
@@ -115,7 +118,7 @@ internal object VirtusizeApi {
         screenResolution: String,
         versionCode: Int
     ): ApiRequest {
-        val url = Uri.parse(environment.apiUrl() + VirtusizeEndpoint.Events.getPath())
+        val url = Uri.parse(environment.defaultApiUrl() + VirtusizeEndpoint.Events.getPath())
             .buildUpon()
             .build()
             .toString()
@@ -192,7 +195,7 @@ internal object VirtusizeApi {
      * @see ApiRequest
      */
     fun sendOrder(order: VirtusizeOrder): ApiRequest {
-        val url = Uri.parse(environment.apiUrl() + VirtusizeEndpoint.Orders.getPath())
+        val url = Uri.parse(environment.defaultApiUrl() + VirtusizeEndpoint.Orders.getPath())
             .buildUpon()
             .build()
             .toString()
@@ -205,7 +208,7 @@ internal object VirtusizeApi {
      * @see ApiRequest
      */
     fun getStoreInfo() : ApiRequest {
-        val url = Uri.parse(environment.apiUrl() + VirtusizeEndpoint.StoreViewApiKey.getPath() + apiKey)
+        val url = Uri.parse(environment.defaultApiUrl() + VirtusizeEndpoint.StoreViewApiKey.getPath() + apiKey)
             .buildUpon()
             .appendQueryParameter("format", "json")
             .build()
@@ -219,7 +222,7 @@ internal object VirtusizeApi {
      * @see ApiRequest
      */
     fun getStoreProductInfo(productId: String) : ApiRequest {
-        val url = Uri.parse(environment.apiUrl() + VirtusizeEndpoint.StoreProducts.getPath() + productId)
+        val url = Uri.parse(environment.defaultApiUrl() + VirtusizeEndpoint.StoreProducts.getPath() + productId)
             .buildUpon()
             .appendQueryParameter("format", "json")
             .build()
@@ -232,7 +235,7 @@ internal object VirtusizeApi {
      * @see ApiRequest
      */
     fun getProductTypes() : ApiRequest {
-        val url = Uri.parse(environment.apiUrl() + VirtusizeEndpoint.ProductType.getPath())
+        val url = Uri.parse(environment.defaultApiUrl() + VirtusizeEndpoint.ProductType.getPath())
             .buildUpon()
             .build()
             .toString()
@@ -256,7 +259,7 @@ internal object VirtusizeApi {
      * @see ApiRequest
      */
     fun getUserProducts(): ApiRequest {
-        val url = Uri.parse(environment.apiUrl() + VirtusizeEndpoint.UserProducts.getPath())
+        val url = Uri.parse(environment.defaultApiUrl() + VirtusizeEndpoint.UserProducts.getPath())
             .buildUpon()
             .build()
             .toString()
@@ -268,10 +271,26 @@ internal object VirtusizeApi {
      * @see ApiRequest
      */
     fun getUserBodyProfile(): ApiRequest {
-        val url = Uri.parse(environment.apiUrl() + VirtusizeEndpoint.UserBodyMeasurements.getPath())
+        val url = Uri.parse(environment.defaultApiUrl() + VirtusizeEndpoint.UserBodyMeasurements.getPath())
             .buildUpon()
             .build()
             .toString()
         return ApiRequest(url, HttpMethod.GET, authorization = true)
+    }
+
+    /**
+     * Gets a API request for getting the recommended size based on the user's body profile
+     * @param productTypes the list of available [ProductType]
+     * @param storeProduct [Product]
+     * @param userBodyProfile [UserBodyProfile]
+     * @see ApiRequest
+     */
+    fun getSize(productTypes: List<ProductType>, storeProduct: Product, userBodyProfile: UserBodyProfile): ApiRequest {
+        val bodyProfileRecommendedSizeParams = BodyProfileRecommendedSizeParams(productTypes, storeProduct, userBodyProfile)
+        val url = Uri.parse(environment.servicesApiUrl() + VirtusizeEndpoint.GetSize.getPath())
+            .buildUpon()
+            .build()
+            .toString()
+        return ApiRequest(url, HttpMethod.POST, bodyProfileRecommendedSizeParams.paramsToMap())
     }
 }

--- a/libsource/src/main/java/com/virtusize/libsource/network/VirtusizeApiTask.kt
+++ b/libsource/src/main/java/com/virtusize/libsource/network/VirtusizeApiTask.kt
@@ -135,7 +135,7 @@ internal class VirtusizeApiTask {
                         // Write the byte array of the request body to the output stream
                         if (apiRequest.params.isNotEmpty()) {
                             val outStream = DataOutputStream(outputStream)
-                            outStream.write(JSONObject(apiRequest.params as Map<String, Any>).toString().toByteArray())
+                            outStream.write(JSONObject(apiRequest.params).toString().toByteArray())
                             outStream.close()
                         }
                     }

--- a/libsource/src/main/java/com/virtusize/libsource/network/VirtusizeApiTask.kt
+++ b/libsource/src/main/java/com/virtusize/libsource/network/VirtusizeApiTask.kt
@@ -135,10 +135,7 @@ internal class VirtusizeApiTask {
                         // Write the byte array of the request body to the output stream
                         if (apiRequest.params.isNotEmpty()) {
                             val outStream = DataOutputStream(outputStream)
-                            outStream.write(
-                                JSONObject(apiRequest.params as Map<String, *>).toString()
-                                    .toByteArray()
-                            )
+                            outStream.write(JSONObject(apiRequest.params as Map<String, Any>).toString().toByteArray())
                             outStream.close()
                         }
                     }

--- a/libsource/src/main/java/com/virtusize/libsource/network/VirtusizeEndpoint.kt
+++ b/libsource/src/main/java/com/virtusize/libsource/network/VirtusizeEndpoint.kt
@@ -5,6 +5,7 @@ package com.virtusize.libsource.network
  */
 internal enum class VirtusizeEndpoint {
     ProductCheck,
+    GetSize,
     Virtusize,
     ProductMetaDataHints,
     Events,
@@ -13,8 +14,8 @@ internal enum class VirtusizeEndpoint {
     StoreProducts,
     UserProducts,
     ProductType,
-    I18N,
-    UserBodyMeasurements
+    UserBodyMeasurements,
+    I18N
 }
 
 /**
@@ -25,6 +26,9 @@ internal fun VirtusizeEndpoint.getPath(): String {
      return when (this) {
          VirtusizeEndpoint.ProductCheck -> {
              "/product/check"
+         }
+         VirtusizeEndpoint.GetSize -> {
+             "/ds-functions/size-rec/get-size"
          }
          VirtusizeEndpoint.Virtusize -> {
              "/a/aoyama/latest/sdk-webview.html"
@@ -50,11 +54,11 @@ internal fun VirtusizeEndpoint.getPath(): String {
          VirtusizeEndpoint.ProductType -> {
              "/a/api/v3/product-types"
          }
-         VirtusizeEndpoint.I18N -> {
-              "/bundle-payloads/aoyama/"
-         }
          VirtusizeEndpoint.UserBodyMeasurements -> {
              "/a/api/v3/user-body-measurements"
+         }
+         VirtusizeEndpoint.I18N -> {
+             "/bundle-payloads/aoyama/"
          }
     }
 }

--- a/libsource/src/test/java/com/virtusize/libsource/TestUtils.kt
+++ b/libsource/src/test/java/com/virtusize/libsource/TestUtils.kt
@@ -1,0 +1,24 @@
+package com.virtusize.libsource
+
+import com.virtusize.libsource.fixtures.TestFixtures
+import org.json.JSONObject
+import java.io.File
+import java.io.IOException
+import java.io.InputStream
+
+internal object TestUtils {
+    fun readFileFromAssets(fileName: String): JSONObject {
+        return try {
+            val file = File(javaClass.getResource(fileName).path)
+            val `is`: InputStream = file.inputStream()
+            val size: Int = `is`.available()
+            val buffer = ByteArray(size)
+            `is`.read(buffer)
+            `is`.close()
+            JSONObject(String(buffer))
+        } catch (e: IOException) {
+            TestFixtures.EMPTY_JSON_DATA
+            throw RuntimeException(e)
+        }
+    }
+}

--- a/libsource/src/test/java/com/virtusize/libsource/VirtusizeTest.kt
+++ b/libsource/src/test/java/com/virtusize/libsource/VirtusizeTest.kt
@@ -340,7 +340,7 @@ class VirtusizeTest {
             }
         )
 
-        assertThat(actualProductTypeList?.size).isEqualTo(2)
+        assertThat(actualProductTypeList?.size).isEqualTo(3)
         assertThat(actualProductTypeList?.get(0)).isEqualTo(
             ProductType(
                 1,
@@ -352,7 +352,7 @@ class VirtusizeTest {
                 )
             )
         )
-        assertThat(actualProductTypeList?.get(1)).isEqualTo(
+        assertThat(actualProductTypeList?.get(2)).isEqualTo(
             ProductType(
                 18,
                 "bag",
@@ -366,13 +366,13 @@ class VirtusizeTest {
     }
 
     @Test
-    fun testGetUserProducts_whenSuccessful_shouldReturnExpectedUserProduct() = runBlocking {
+    fun testGetUserProductsResponse_userHasItemsInTheWardrobe_shouldReturnExpectedUserProducts() = runBlocking {
         virtusize.setHTTPURLConnection(MockHttpURLConnection(
             mockURL,
             MockedResponse(200, ProductFixtures.USER_PRODUCT_JSON_ARRAY.toString().byteInputStream())
         ))
 
-        val actualApiResponse = virtusize.getUserProductsApiResponse()
+        val actualApiResponse = virtusize.getUserProductsResponse()
         assertThat(actualApiResponse is VirtusizeApiResponse.Success<List<Product>?>)
         val actualUserProductList = (actualApiResponse as? VirtusizeApiResponse.Success<List<Product>?>)?.data
         assertThat(actualUserProductList?.size).isEqualTo(2)
@@ -394,26 +394,26 @@ class VirtusizeTest {
     }
 
     @Test
-    fun testGetUserProducts_emptyWardrobe_shouldReturnEmptyUserProductList() = runBlocking {
+    fun testGetUserProductsResponse_userHasEmptyWardrobe_shouldReturnEmptyUserProductList() = runBlocking {
         virtusize.setHTTPURLConnection(MockHttpURLConnection(
             mockURL,
             MockedResponse(200, ProductFixtures.EMPTY_PRODUCT_JSON_ARRAY.toString().byteInputStream())
         ))
 
-        val actualApiResponse = virtusize.getUserProductsApiResponse()
+        val actualApiResponse = virtusize.getUserProductsResponse()
         assertThat(actualApiResponse is VirtusizeApiResponse.Success<List<Product>?>)
         val actualUserProductList = (actualApiResponse as? VirtusizeApiResponse.Success<List<Product>?>)?.data
         assertThat(actualUserProductList?.size).isEqualTo(0)
     }
 
     @Test
-    fun testGetUserProducts_wardrobeNotExisted_shouldReturn404Error() = runBlocking {
+    fun testGetUserProductsResponse_wardrobeDoesNotExist_shouldReturn404Error() = runBlocking {
         virtusize.setHTTPURLConnection(MockHttpURLConnection(
             mockURL,
             MockedResponse(404, ProductFixtures.WARDROBE_NOT_FOUND_ERROR_JSONObject.toString().byteInputStream())
         ))
 
-        val actualApiResponse = virtusize.getUserProductsApiResponse()
+        val actualApiResponse = virtusize.getUserProductsResponse()
         assertThat(actualApiResponse is VirtusizeApiResponse.Error)
         val actualError = (actualApiResponse as? VirtusizeApiResponse.Error)?.error
 
@@ -423,7 +423,7 @@ class VirtusizeTest {
     }
 
     @Test
-    fun testGetUserBodyProfile_getsValidUserBodyProfile_shouldHaveExpectedUserBodyProfile() = runBlocking {
+    fun testGetUserBodyProfileResponse_userHasValidBodyProfile_shouldReturnExpectedBodyProfile() = runBlocking {
         virtusize.setHTTPURLConnection(MockHttpURLConnection(
             mockURL,
             MockedResponse(200, TestFixtures.USER_BODY_JSONObject.toString().byteInputStream())
@@ -466,7 +466,7 @@ class VirtusizeTest {
     }
 
     @Test
-    fun testGetUserBodyProfile_getsEmptyUserBodyProfile_shouldExpectNull() = runBlocking {
+    fun testGetUserBodyProfileResponse_userHasEmptyBodyProfile_shouldExpectNull() = runBlocking {
         virtusize.setHTTPURLConnection(MockHttpURLConnection(
             mockURL,
             MockedResponse(200, TestFixtures.NULL_USER_BODY_PROFILE.toString().byteInputStream())
@@ -480,7 +480,7 @@ class VirtusizeTest {
     }
 
     @Test
-    fun testGetUserBodyProfile_wardrobeNotExisted_shouldReturn404Error() = runBlocking {
+    fun testGetUserBodyProfileResponse_wardrobeDoesNotExist_shouldReturn404Error() = runBlocking {
         virtusize.setHTTPURLConnection(MockHttpURLConnection(
             mockURL,
             MockedResponse(404, ProductFixtures.WARDROBE_NOT_FOUND_ERROR_JSONObject.toString().byteInputStream())
@@ -493,6 +493,21 @@ class VirtusizeTest {
         assertThat(actualError?.code).isEqualTo(HttpURLConnection.HTTP_NOT_FOUND)
         assertThat(actualError?.message).contains("{\"detail\":\"No wardrobe found\"}")
         assertThat(actualError?.type).isEqualTo(VirtusizeErrorType.NetworkError)
+    }
+
+    @Test
+    fun testI18nResponse_whenSuccessful_shouldReturnExpectedI18Localization() = runBlocking {
+        virtusize.setHTTPURLConnection(MockHttpURLConnection(
+            mockURL,
+            MockedResponse(200, TestUtils.readFileFromAssets("/i18n_en.json").toString().byteInputStream())
+        ))
+
+        val actualApiResponse = virtusize.getI18nResponse()
+        assertThat(actualApiResponse is VirtusizeApiResponse.Success<I18nLocalization?>)
+        val actualI18nLocalization = (actualApiResponse as? VirtusizeApiResponse.Success<I18nLocalization?>)?.data
+
+        assertThat(actualI18nLocalization?.defaultNoDataText).isEqualTo("Find the right size before purchasing")
+        assertThat(actualI18nLocalization?.defaultAccessoryText).isEqualTo("See how everyday items fit")
     }
 
     companion object {

--- a/libsource/src/test/java/com/virtusize/libsource/VirtusizeTest.kt
+++ b/libsource/src/test/java/com/virtusize/libsource/VirtusizeTest.kt
@@ -289,7 +289,35 @@ class VirtusizeTest {
         assertThat(actualProduct?.name).isEqualTo(TestFixtures.PRODUCT_NAME)
         assertThat(actualProduct?.storeId).isEqualTo(TestFixtures.STORE_ID)
         assertThat(actualProduct?.storeProductMeta?.id).isEqualTo(1)
+        assertThat(actualProduct?.storeProductMeta?.id).isEqualTo(1)
         val expectedAdditionalInfo = StoreProductAdditionalInfo(
+            "Virtusize",
+            "female",
+            mutableSetOf(
+                ProductSize(
+                    "38",
+                    mutableSetOf(
+                        Measurement("height", 760),
+                        Measurement("bust", 660),
+                        Measurement("sleeve", 845)
+                    )
+                ),
+                ProductSize(
+                    "36",
+                    mutableSetOf(
+                        Measurement("height", 750),
+                        Measurement("bust", 645),
+                        Measurement("sleeve", 825)
+                    )
+                )
+            ),
+            mutableMapOf(
+                "hip" to 85,
+                "size" to "38",
+                "waist" to 56,
+                "bust" to 78,
+                "height" to 165
+            ),
             "regular",
             "fashionable",
             BrandSizing("large", false)

--- a/libsource/src/test/java/com/virtusize/libsource/data/local/BodyProfileRecommendedSizeParamsTests.kt
+++ b/libsource/src/test/java/com/virtusize/libsource/data/local/BodyProfileRecommendedSizeParamsTests.kt
@@ -1,0 +1,41 @@
+package com.virtusize.libsource.data.local
+
+import com.google.common.truth.Truth.assertThat
+import com.virtusize.libsource.fixtures.ProductFixtures
+import com.virtusize.libsource.fixtures.TestFixtures
+import org.json.JSONObject
+import org.junit.Before
+import org.junit.Test
+
+class BodyProfileRecommendedSizeParamsTests {
+
+    @Test
+    fun testCreateAdditionalInfoParams_fullInfo_getExpectedRequestBody() {
+        val bodyProfileRecommendedSizeParams = BodyProfileRecommendedSizeParams(ProductFixtures.storeProduct(), TestFixtures.userBodyProfile)
+        val actualAdditionalInfoParams = bodyProfileRecommendedSizeParams.createAdditionalInfoParams()
+        assertThat(JSONObject(actualAdditionalInfoParams).toString()).isEqualTo(
+            """
+                {"fit":"regular","sizes":{"38":{"bust":660,"sleeve":845,"height":760},"36":{"bust":645,"sleeve":825,"height":750}},"gender":"female","brand":"Virtusize","model_info":{"waist":56,"bust":78,"size":"38","hip":85,"height":165}}
+            """.trimIndent()
+        )
+    }
+
+    @Test
+    fun testCreateAdditionalInfoParams_hasEmptyValues_getExpectedRequestBody() {
+        val bodyProfileRecommendedSizeParams = BodyProfileRecommendedSizeParams(
+            ProductFixtures.storeProduct(
+                sizeList = mutableListOf(),
+                brand = "",
+                modelInfo = null,
+                gender = null
+            ),
+            TestFixtures.userBodyProfile
+        )
+        val actualAdditionalInfoParams = bodyProfileRecommendedSizeParams.createAdditionalInfoParams()
+        assertThat(JSONObject(actualAdditionalInfoParams).toString()).isEqualTo(
+            """
+                {"fit":"regular","sizes":{},"gender":null,"brand":"","model_info":"{}"}
+            """.trimIndent()
+        )
+    }
+}

--- a/libsource/src/test/java/com/virtusize/libsource/data/local/BodyProfileRecommendedSizeParamsTests.kt
+++ b/libsource/src/test/java/com/virtusize/libsource/data/local/BodyProfileRecommendedSizeParamsTests.kt
@@ -1,6 +1,8 @@
 package com.virtusize.libsource.data.local
 
 import com.google.common.truth.Truth.assertThat
+import com.virtusize.libsource.data.parsers.ProductTypeJsonParser
+import com.virtusize.libsource.data.remote.ProductType
 import com.virtusize.libsource.fixtures.ProductFixtures
 import com.virtusize.libsource.fixtures.TestFixtures
 import org.json.JSONObject
@@ -9,20 +11,59 @@ import org.junit.Test
 
 class BodyProfileRecommendedSizeParamsTests {
 
+    private var productTypes = mutableListOf<ProductType>()
+
+    @Before
+    fun setup() {
+        for (i in 0 until ProductFixtures.PRODUCT_TYPE_JSON_ARRAY.length()) {
+            ProductTypeJsonParser().parse(ProductFixtures.PRODUCT_TYPE_JSON_ARRAY[i] as JSONObject)?.let {
+                productTypes.add(it)
+            }
+        }
+    }
+
     @Test
-    fun testCreateAdditionalInfoParams_fullInfo_getExpectedRequestBody() {
-        val bodyProfileRecommendedSizeParams = BodyProfileRecommendedSizeParams(ProductFixtures.storeProduct(), TestFixtures.userBodyProfile)
+    fun testCreateAdditionalInfoParams_fullInfo_getExpectedRequestBodyString() {
+        val bodyProfileRecommendedSizeParams = BodyProfileRecommendedSizeParams(
+            productTypes,
+            ProductFixtures.storeProduct(),
+            TestFixtures.userBodyProfile
+        )
         val actualAdditionalInfoParams = bodyProfileRecommendedSizeParams.createAdditionalInfoParams()
         assertThat(JSONObject(actualAdditionalInfoParams).toString()).isEqualTo(
             """
-                {"fit":"regular","sizes":{"38":{"bust":660,"sleeve":845,"height":760},"36":{"bust":645,"sleeve":825,"height":750}},"gender":"female","brand":"Virtusize","model_info":{"waist":56,"bust":78,"size":"38","hip":85,"height":165}}
-            """.trimIndent()
+                {
+                    "fit": "regular",
+                    "sizes": {
+                        "38": {
+                            "bust": 660,
+                            "sleeve": 845,
+                            "height": 760
+                        },
+                        "36": {
+                            "bust": 645,
+                            "sleeve": 825,
+                            "height": 750
+                        }
+                    },
+                    "gender": "female",
+                    "brand": "Virtusize",
+                    "model_info": {
+                        "waist": 56,
+                        "bust": 78,
+                        "size": "38",
+                        "hip": 85,
+                        "height": 165
+                    }
+                }
+            """.trimIndent().replace("\\s+|[\\n]+".toRegex(), "")
         )
     }
 
     @Test
-    fun testCreateAdditionalInfoParams_hasEmptyValues_getExpectedRequestBody() {
+    fun testCreateAdditionalInfoParams_hasEmptyValues_getExpectedRequestBodyString() {
         val bodyProfileRecommendedSizeParams = BodyProfileRecommendedSizeParams(
+            productTypes,
             ProductFixtures.storeProduct(
                 sizeList = mutableListOf(),
                 brand = "",
@@ -34,8 +75,288 @@ class BodyProfileRecommendedSizeParamsTests {
         val actualAdditionalInfoParams = bodyProfileRecommendedSizeParams.createAdditionalInfoParams()
         assertThat(JSONObject(actualAdditionalInfoParams).toString()).isEqualTo(
             """
-                {"fit":"regular","sizes":{},"gender":null,"brand":"","model_info":"{}"}
-            """.trimIndent()
+                {
+                    "fit": "regular",
+                    "sizes": {},
+                    "gender": null,
+                    "brand": "",
+                    "model_info": "{}"
+                }
+            """.trimIndent().replace("\\s+|[\\n]+".toRegex(), "")
+        )
+    }
+
+    @Test
+    fun testCreateBodyDataParams_getExpectedRequestBodyString() {
+        val bodyProfileRecommendedSizeParams = BodyProfileRecommendedSizeParams(
+            productTypes,
+            ProductFixtures.storeProduct(),
+            TestFixtures.userBodyProfile
+        )
+        val bodyDataParams = bodyProfileRecommendedSizeParams.createBodyDataParams()
+        assertThat(JSONObject(bodyDataParams).toString()).isEqualTo(
+            """
+            {
+                "waistWidth": {
+                    "value": 225,
+                    "predicted": true
+                },
+                "chest": {
+                    "value": 755,
+                    "predicted": true
+                },
+                "bustWidth": {
+                    "value": 245,
+                    "predicted": true
+                },
+                "thigh": {
+                    "value": 480,
+                    "predicted": true
+                },
+                "shoulderWidth": {
+                    "value": 340,
+                    "predicted": true
+                },
+                "hipHeight": {
+                    "value": 750,
+                    "predicted": true
+                },
+                "kneeHeight": {
+                    "value": 395,
+                    "predicted": true
+                },
+                "neck": {
+                    "value": 300,
+                    "predicted": true
+                },
+                "waistHeight": {
+                    "value": 920,
+                    "predicted": true
+                },
+                "hip": {
+                    "value": 830,
+                    "predicted": true
+                },
+                "armpitHeight": {
+                    "value": 1130,
+                    "predicted": true
+                },
+                "bicep": {
+                    "value": 220,
+                    "predicted": true
+                },
+                "inseam": {
+                    "value": 700,
+                    "predicted": true
+                },
+                "headHeight": {
+                    "value": 215,
+                    "predicted": true
+                },
+                "hipWidth": {
+                    "value": 300,
+                    "predicted": true
+                },
+                "sleeve": {
+                    "value": 720,
+                    "predicted": true
+                },
+                "bust": {
+                    "value": 755,
+                    "predicted": true
+                },
+                "waist": {
+                    "value": 630,
+                    "predicted": true
+                },
+                "sleeveLength": {
+                    "value": 520,
+                    "predicted": true
+                },
+                "rise": {
+                    "value": 215,
+                    "predicted": true
+                },
+                "shoulder": {
+                    "value": 370,
+                    "predicted": true
+                },
+                "shoulderHeight": {
+                    "value": 1240,
+                    "predicted": true
+                }
+            }
+            """.trimIndent().replace("\\s+|[\\n]+".toRegex(), "")
+        )
+    }
+
+    @Test
+    fun testCreateItemSizesParams_getExpectedRequestBodyString() {
+        val bodyProfileRecommendedSizeParams = BodyProfileRecommendedSizeParams(
+            productTypes,
+            ProductFixtures.storeProduct(),
+            TestFixtures.userBodyProfile
+        )
+        val itemSizesParams = bodyProfileRecommendedSizeParams.createItemSizesParams()
+        assertThat(JSONObject(itemSizesParams).toString().trimIndent()).isEqualTo(
+            """
+                {
+                    "38": {
+                        "bust": 660,
+                        "sleeve": 845,
+                        "height": 760
+                    },
+                    "36": {
+                        "bust": 645,
+                        "sleeve": 825,
+                        "height": 750
+                    }
+                }
+            """.trimIndent().replace("\\s+|[\\n]+".toRegex(), "")
+        )
+    }
+
+    @Test
+    fun testBodyProfileRecommendedSizeParams_getExpectedRequestBodyString() {
+        val bodyProfileRecommendedSizeParams = BodyProfileRecommendedSizeParams(
+            productTypes,
+            ProductFixtures.storeProduct(),
+            TestFixtures.userBodyProfile
+        )
+        val bodyProfileRecommendedSizeParamsMap = bodyProfileRecommendedSizeParams.paramsToMap()
+        assertThat(JSONObject(bodyProfileRecommendedSizeParamsMap).toString()).isEqualTo(
+            """
+                {
+                    "user_gender": "female",
+                    "item_sizes_orig": {
+                        "38": {
+                            "bust": 660,
+                            "sleeve": 845,
+                            "height": 760
+                        },
+                        "36": {
+                            "bust": 645,
+                            "sleeve": 825,
+                            "height": 750
+                        }
+                    },
+                    "product_type": "jacket",
+                    "additional_info": {
+                        "fit": "regular",
+                        "sizes": {
+                            "38": {
+                                "bust": 660,
+                                "sleeve": 845,
+                                "height": 760
+                            },
+                            "36": {
+                                "bust": 645,
+                                "sleeve": 825,
+                                "height": 750
+                            }
+                        },
+                        "gender": "female",
+                        "brand": "Virtusize",
+                        "model_info": {
+                            "waist": 56,
+                            "bust": 78,
+                            "size": "38",
+                            "hip": 85,
+                            "height": 165
+                        }
+                    },
+                    "body_data": {
+                        "waistWidth": {
+                            "value": 225,
+                            "predicted": true
+                        },
+                        "chest": {
+                            "value": 755,
+                            "predicted": true
+                        },
+                        "bustWidth": {
+                            "value": 245,
+                            "predicted": true
+                        },
+                        "thigh": {
+                            "value": 480,
+                            "predicted": true
+                        },
+                        "shoulderWidth": {
+                            "value": 340,
+                            "predicted": true
+                        },
+                        "hipHeight": {
+                            "value": 750,
+                            "predicted": true
+                        },
+                        "kneeHeight": {
+                            "value": 395,
+                            "predicted": true
+                        },
+                        "neck": {
+                            "value": 300,
+                            "predicted": true
+                        },
+                        "waistHeight": {
+                            "value": 920,
+                            "predicted": true
+                        },
+                        "hip": {
+                            "value": 830,
+                            "predicted": true
+                        },
+                        "armpitHeight": {
+                            "value": 1130,
+                            "predicted": true
+                        },
+                        "bicep": {
+                            "value": 220,
+                            "predicted": true
+                        },
+                        "inseam": {
+                            "value": 700,
+                            "predicted": true
+                        },
+                        "headHeight": {
+                            "value": 215,
+                            "predicted": true
+                        },
+                        "hipWidth": {
+                            "value": 300,
+                            "predicted": true
+                        },
+                        "sleeve": {
+                            "value": 720,
+                            "predicted": true
+                        },
+                        "bust": {
+                            "value": 755,
+                            "predicted": true
+                        },
+                        "waist": {
+                            "value": 630,
+                            "predicted": true
+                        },
+                        "sleeveLength": {
+                            "value": 520,
+                            "predicted": true
+                        },
+                        "rise": {
+                            "value": 215,
+                            "predicted": true
+                        },
+                        "shoulder": {
+                            "value": 370,
+                            "predicted": true
+                        },
+                        "shoulderHeight": {
+                            "value": 1240,
+                            "predicted": true
+                        }
+                    }
+                }
+            """.trimIndent().replace("\\s+|[\\n]+".toRegex(), "")
         )
     }
 }

--- a/libsource/src/test/java/com/virtusize/libsource/data/local/BodyProfileRecommendedSizeParamsTests.kt
+++ b/libsource/src/test/java/com/virtusize/libsource/data/local/BodyProfileRecommendedSizeParamsTests.kt
@@ -15,11 +15,7 @@ class BodyProfileRecommendedSizeParamsTests {
 
     @Before
     fun setup() {
-        for (i in 0 until ProductFixtures.PRODUCT_TYPE_JSON_ARRAY.length()) {
-            ProductTypeJsonParser().parse(ProductFixtures.PRODUCT_TYPE_JSON_ARRAY[i] as JSONObject)?.let {
-                productTypes.add(it)
-            }
-        }
+        productTypes = ProductFixtures.productTypes()
     }
 
     @Test

--- a/libsource/src/test/java/com/virtusize/libsource/data/local/BodyProfileRecommendedSizeParamsTests.kt
+++ b/libsource/src/test/java/com/virtusize/libsource/data/local/BodyProfileRecommendedSizeParamsTests.kt
@@ -76,7 +76,7 @@ class BodyProfileRecommendedSizeParamsTests {
                     "sizes": {},
                     "gender": null,
                     "brand": "",
-                    "model_info": "{}"
+                    "model_info": {}
                 }
             """.trimIndent().replace("\\s+|[\\n]+".toRegex(), "")
         )

--- a/libsource/src/test/java/com/virtusize/libsource/data/parsers/I18nLocalizationJsonParserTest.kt
+++ b/libsource/src/test/java/com/virtusize/libsource/data/parsers/I18nLocalizationJsonParserTest.kt
@@ -5,18 +5,15 @@ import android.content.res.Configuration
 import android.os.Build
 import androidx.test.core.app.ApplicationProvider
 import com.google.common.truth.Truth.assertThat
+import com.virtusize.libsource.TestUtils
 import com.virtusize.libsource.R
 import com.virtusize.libsource.fixtures.TestFixtures
 import com.virtusize.libsource.data.local.VirtusizeLanguage
 import com.virtusize.libsource.data.remote.I18nLocalization
-import org.json.JSONObject
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.annotation.Config
-import java.io.File
-import java.io.IOException
-import java.io.InputStream
 import java.util.*
 
 @RunWith(RobolectricTestRunner::class)
@@ -27,7 +24,8 @@ class I18nLocalizationJsonParserTest {
 
     @Test
     fun parseI18N_englishLocalization_shouldReturnExpectedObject() {
-        val actualI18nLocalization = I18nLocalizationJsonParser(context, VirtusizeLanguage.EN).parse(readFileFromAssets("/i18n_en.json"))
+        val actualI18nLocalization = I18nLocalizationJsonParser(context, VirtusizeLanguage.EN).parse(
+            TestUtils.readFileFromAssets("/i18n_en.json"))
 
         val expectedI18nLocalization = I18nLocalization(
             context.getString(R.string.inpage_default_accessory_text),
@@ -52,7 +50,7 @@ class I18nLocalizationJsonParserTest {
 
     @Test
     fun parseI18NJP_japaneseLocalization_shouldReturnExpectedObject() {
-        val actualI18nLocalization = I18nLocalizationJsonParser(context, VirtusizeLanguage.JP).parse(readFileFromAssets("/i18n_jp.json"))
+        val actualI18nLocalization = I18nLocalizationJsonParser(context, VirtusizeLanguage.JP).parse(TestUtils.readFileFromAssets("/i18n_jp.json"))
 
         var conf: Configuration = context.resources.configuration
         conf = Configuration(conf)
@@ -68,7 +66,7 @@ class I18nLocalizationJsonParserTest {
 
     @Test
     fun parseI18NKO_koreanLocalization_shouldReturnExpectedObject() {
-        val actualI18nLocalization = I18nLocalizationJsonParser(context, VirtusizeLanguage.KR).parse(readFileFromAssets("/i18n_ko.json"))
+        val actualI18nLocalization = I18nLocalizationJsonParser(context, VirtusizeLanguage.KR).parse(TestUtils.readFileFromAssets("/i18n_ko.json"))
 
         var conf: Configuration = context.resources.configuration
         conf = Configuration(conf)
@@ -80,20 +78,5 @@ class I18nLocalizationJsonParserTest {
         )
 
         assertThat(actualI18nLocalization).isEqualTo(expectedI18nLocalization)
-    }
-
-    private fun readFileFromAssets(fileName: String): JSONObject {
-        return try {
-            val file = File(javaClass.getResource(fileName).path)
-            val `is`: InputStream = file.inputStream()
-            val size: Int = `is`.available()
-            val buffer = ByteArray(size)
-            `is`.read(buffer)
-            `is`.close()
-            JSONObject(String(buffer))
-        } catch (e: IOException) {
-            TestFixtures.EMPTY_JSON_DATA
-            throw RuntimeException(e)
-        }
     }
 }

--- a/libsource/src/test/java/com/virtusize/libsource/data/parsers/StoreProductAdditionalInfoJsonParserTest.kt
+++ b/libsource/src/test/java/com/virtusize/libsource/data/parsers/StoreProductAdditionalInfoJsonParserTest.kt
@@ -3,32 +3,32 @@ package com.virtusize.libsource.data.parsers
 import com.google.common.truth.Truth.assertThat
 import com.virtusize.libsource.fixtures.TestFixtures
 import com.virtusize.libsource.data.remote.BrandSizing
-import com.virtusize.libsource.data.remote.StoreProductAdditionalInfo
 import org.json.JSONObject
 import org.junit.Test
 
 class StoreProductAdditionalInfoJsonParserTest {
 
     @Test
-    fun parse_validJsonData_shouldReturnExpectedObject() {
-        val actualAdditionalInfo = StoreProductAdditionalInfoJsonParser().parse(ADDITIONAL_INFO_JSON_DATA)
+    fun parse_validJsonData_shouldReturnExpectedStoreProductAdditionalInfo() {
+        val actualAdditionalInfo = StoreProductAdditionalInfoJsonParser().parse(ADDITIONAL_INFO_JSON_DATA
+        )
 
-        val expectedAdditionalInfo = StoreProductAdditionalInfo(
-            "wide",
-            "regular",
+        assertThat(actualAdditionalInfo?.brand).isEqualTo("Virtusize")
+        assertThat(actualAdditionalInfo?.sizes?.size).isEqualTo(0)
+        assertThat(actualAdditionalInfo?.modelInfo).isEqualTo(mutableMapOf<String, Any>())
+        assertThat(actualAdditionalInfo?.fit).isEqualTo("wide")
+        assertThat(actualAdditionalInfo?.style).isEqualTo("regular")
+        assertThat(actualAdditionalInfo?.brandSizing).isEqualTo(
             BrandSizing(
                 "true",
                 true
             )
         )
-
-        assertThat(actualAdditionalInfo).isEqualTo(expectedAdditionalInfo)
     }
 
     @Test
-    fun parse_emptyJsonData_shouldReturnExpectedObject() {
+    fun parse_emptyJsonData_shouldReturnNull() {
         val actualAdditionalInfo = StoreProductAdditionalInfoJsonParser().parse(TestFixtures.EMPTY_JSON_DATA)
-
         assertThat(actualAdditionalInfo).isNull()
     }
 

--- a/libsource/src/test/java/com/virtusize/libsource/data/parsers/StoreProductJsonParserTest.kt
+++ b/libsource/src/test/java/com/virtusize/libsource/data/parsers/StoreProductJsonParserTest.kt
@@ -1,6 +1,7 @@
 package com.virtusize.libsource.data.parsers
 
 import com.google.common.truth.Truth.assertThat
+import com.virtusize.libsource.data.remote.*
 import com.virtusize.libsource.fixtures.ProductFixtures
 import com.virtusize.libsource.fixtures.TestFixtures
 import org.junit.Test
@@ -8,12 +9,68 @@ import org.junit.Test
 class StoreProductJsonParserTest {
 
     @Test
-    fun parse_validJsonData_shouldReturnExpectedObject() {
+    fun parse_validJsonData_shouldReturnExpectedStoreProduct() {
         val actualStoreProduct = StoreProductJsonParser().parse(ProductFixtures.STORE_PRODUCT_INFO_JSON_DATA)
-
-        val expectedStoreProduct = ProductFixtures.storeProduct()
-
-        assertThat(actualStoreProduct).isEqualTo(expectedStoreProduct)
+        assertThat(actualStoreProduct?.id).isEqualTo(7110384)
+        assertThat(actualStoreProduct?.sizes?.size).isEqualTo(2)
+        assertThat(actualStoreProduct?.sizes?.toMutableList()).isEqualTo(
+            mutableListOf(
+                ProductSize(
+                    "38",
+                    mutableSetOf(
+                        Measurement("height", 760),
+                        Measurement("bust", 660),
+                        Measurement("sleeve", 845)
+                    )
+                ),
+                ProductSize(
+                    "36",
+                    mutableSetOf(
+                        Measurement("height", 750),
+                        Measurement("bust", 645),
+                        Measurement("sleeve", 825)
+                    )
+                )
+            )
+        )
+        assertThat(actualStoreProduct?.externalId).isEqualTo("694")
+        assertThat(actualStoreProduct?.productType).isEqualTo(8)
+        assertThat(actualStoreProduct?.name).isEqualTo("Test Product Name")
+        assertThat(actualStoreProduct?.cloudinaryPublicId).isEqualTo("Test Cloudinary Public Id")
+        assertThat(actualStoreProduct?.isFavorite).isNull()
+        assertThat(actualStoreProduct?.storeId).isEqualTo(2)
+        assertThat(actualStoreProduct?.storeProductMeta?.id).isEqualTo(1)
+        assertThat(actualStoreProduct?.storeProductMeta?.brand).isEqualTo("Virtusize")
+        assertThat(actualStoreProduct?.storeProductMeta?.additionalInfo?.brand).isEqualTo("Virtusize")
+        assertThat(actualStoreProduct?.storeProductMeta?.additionalInfo?.sizes?.toMutableSet()).isEqualTo(
+            mutableSetOf(ProductSize(
+                "38",
+                mutableSetOf(
+                    Measurement("height", 760),
+                    Measurement("bust", 660),
+                    Measurement("sleeve", 845)
+                )
+            ),
+                ProductSize(
+                    "36",
+                    mutableSetOf(
+                        Measurement("height", 750),
+                        Measurement("bust", 645),
+                        Measurement("sleeve", 825)
+                    )
+                )))
+        assertThat(actualStoreProduct?.storeProductMeta?.additionalInfo?.modelInfo).isEqualTo(
+            mutableMapOf(
+                "hip" to 85,
+                "size" to "38",
+                "waist" to 56,
+                "bust" to 78,
+                "height" to 165
+            )
+        )
+        assertThat(actualStoreProduct?.storeProductMeta?.additionalInfo?.fit).isEqualTo("regular")
+        assertThat(actualStoreProduct?.storeProductMeta?.additionalInfo?.style).isEqualTo("fashionable")
+        assertThat(actualStoreProduct?.storeProductMeta?.additionalInfo?.brandSizing).isEqualTo(BrandSizing("large", false))
     }
 
     @Test

--- a/libsource/src/test/java/com/virtusize/libsource/data/parsers/StoreProductMetaJsonParserTest.kt
+++ b/libsource/src/test/java/com/virtusize/libsource/data/parsers/StoreProductMetaJsonParserTest.kt
@@ -1,25 +1,48 @@
 package com.virtusize.libsource.data.parsers
 
 import com.google.common.truth.Truth.assertThat
+import com.virtusize.libsource.data.remote.*
 import com.virtusize.libsource.fixtures.TestFixtures
-import com.virtusize.libsource.data.remote.BrandSizing
-import com.virtusize.libsource.data.remote.StoreProductAdditionalInfo
-import com.virtusize.libsource.data.remote.StoreProductMeta
 import org.json.JSONObject
 import org.junit.Test
 
 class StoreProductMetaJsonParserTest {
 
     @Test
-    fun parse_validJsonData_shouldReturnExpectedObject() {
+    fun parse_validJsonData_shouldReturnExpectedStoreProductMeta() {
         val actualStoreProductMeta = StoreProductMetaJsonParser().parse(STORE_PRODUCT_META_JSON_DATA)
-
-        val expectedStoreProductMeta = StoreProductMeta(
-            123,
-            StoreProductAdditionalInfo("loose", "fashionable", BrandSizing("small", true))
+        assertThat(actualStoreProductMeta?.id).isEqualTo(123)
+        assertThat(actualStoreProductMeta?.brand).isEqualTo("Virtusize")
+        assertThat(actualStoreProductMeta?.additionalInfo?.brand).isEqualTo("Virtusize")
+        assertThat(actualStoreProductMeta?.additionalInfo?.sizes?.toMutableSet()).isEqualTo(
+            mutableSetOf(ProductSize(
+                "38",
+                mutableSetOf(
+                    Measurement("height", 760),
+                    Measurement("bust", 660),
+                    Measurement("sleeve", 845)
+                )
+            ),
+                ProductSize(
+                    "36",
+                    mutableSetOf(
+                        Measurement("height", 750),
+                        Measurement("bust", 645),
+                        Measurement("sleeve", 825)
+                    )
+                )))
+        assertThat(actualStoreProductMeta?.additionalInfo?.modelInfo).isEqualTo(
+            mutableMapOf(
+                "hip" to 85,
+                "size" to "38",
+                "waist" to 56,
+                "bust" to 78,
+                "height" to 165
+            )
         )
-
-        assertThat(actualStoreProductMeta).isEqualTo(expectedStoreProductMeta)
+        assertThat(actualStoreProductMeta?.additionalInfo?.fit).isEqualTo("loose")
+        assertThat(actualStoreProductMeta?.additionalInfo?.style).isEqualTo("fashionable")
+        assertThat(actualStoreProductMeta?.additionalInfo?.brandSizing).isEqualTo(BrandSizing("small", true))
     }
 
     @Test

--- a/libsource/src/test/java/com/virtusize/libsource/data/parsers/UserBodyProfileJsonParserTest.kt
+++ b/libsource/src/test/java/com/virtusize/libsource/data/parsers/UserBodyProfileJsonParserTest.kt
@@ -1,8 +1,6 @@
 package com.virtusize.libsource.data.parsers
 
 import com.google.common.truth.Truth.assertThat
-import com.virtusize.libsource.data.remote.Measurement
-import com.virtusize.libsource.data.remote.UserBodyProfile
 import com.virtusize.libsource.fixtures.TestFixtures
 import org.junit.Test
 
@@ -11,39 +9,7 @@ class UserBodyProfileJsonParserTest {
     @Test
     fun test_parseValidUserBodyResponse_returnExpectedUserBodyProfile() {
         val actualUserBodyProfile = UserBodyProfileJsonParser().parse(TestFixtures.USER_BODY_JSONObject)
-
-        val expectedUserBodyProfile = UserBodyProfile(
-            "female",
-            32,
-            1630,
-            "50.00",
-            mutableSetOf(
-                Measurement("hip", 830),
-                Measurement("hip", 830),
-                Measurement("bust", 755),
-                Measurement("neck", 300),
-                Measurement("rise", 215),
-                Measurement("bicep", 220),
-                Measurement("thigh", 480),
-                Measurement("waist", 630),
-                Measurement("inseam", 700),
-                Measurement("sleeve", 720),
-                Measurement("shoulder", 370),
-                Measurement("hipWidth", 300),
-                Measurement("bustWidth", 245),
-                Measurement("hipHeight", 750),
-                Measurement("headHeight", 215),
-                Measurement("kneeHeight", 395),
-                Measurement("waistWidth", 225),
-                Measurement("waistHeight", 920),
-                Measurement("armpitHeight", 1130),
-                Measurement("sleeveLength", 520),
-                Measurement("shoulderWidth", 340),
-                Measurement("shoulderHeight", 1240)
-            )
-        )
-
-        assertThat(actualUserBodyProfile).isEqualTo(expectedUserBodyProfile)
+        assertThat(actualUserBodyProfile).isEqualTo(TestFixtures.userBodyProfile)
     }
 
     @Test

--- a/libsource/src/test/java/com/virtusize/libsource/fixtures/ProductFixtures.kt
+++ b/libsource/src/test/java/com/virtusize/libsource/fixtures/ProductFixtures.kt
@@ -82,6 +82,84 @@ internal object ProductFixtures {
             }
         """.trimIndent()
 
+    private val PRODUCT_TYPE_ID_EIGHT_JSON_OBJECT_STRING =
+        """
+            {
+                "id": 8,
+                "name": "jacket",
+                "optionalMeasurements": [
+                  "shoulder",
+                  "waist",
+                  "hem",
+                  "bicep"
+                ],
+                "priority": [
+                  "bust",
+                  "sleeve"
+                ],
+                "requiredMeasurements": [
+                  "height",
+                  "bust",
+                  "sleeve"
+                ],
+                "supportsLengthComparison": true,
+                "weights": {
+                  "bust": 2,
+                  "height": 1,
+                  "sleeve": 1
+                },
+                "anchorPoint": "shoulders",
+                "compatibleWith": [
+                  8,
+                  14
+                ],
+                "defaultMeasurements": {
+                  "hem": 560,
+                  "bust": 540,
+                  "bicep": 180,
+                  "waist": 480,
+                  "height": 810,
+                  "sleeve": 900,
+                  "shoulder": 470
+                },
+                "displayMode": "portrait",
+                "isDraggable": false,
+                "isReserved": false,
+                "maxMeasurements": {
+                  "hem": 1300,
+                  "bust": 1300,
+                  "bicep": 450,
+                  "waist": 1300,
+                  "height": 1800,
+                  "sleeve": 1300,
+                  "shoulder": 1100
+                },
+                "minMeasurements": {
+                  "hem": 300,
+                  "bust": 300,
+                  "bicep": 70,
+                  "waist": 200,
+                  "height": 350,
+                  "sleeve": 200,
+                  "shoulder": 250
+                },
+                "sgiGenders": [
+                  "unisex",
+                  "male",
+                  "female"
+                ],
+                "sgiStyles": [
+                  "regular",
+                  "formal",
+                  "fashionable",
+                  "protective"
+                ],
+                "sgiTypes": [
+                  "regular"
+                ]
+            }
+        """.trimIndent()
+
     private val PRODUCT_TYPE_ID_EIGHTEEN_JSON_OBJECT_STRING =
         """
             {
@@ -162,6 +240,7 @@ internal object ProductFixtures {
         """
             [
                 $PRODUCT_TYPE_ID_ONE_JSON_OBJECT_STRING,
+                $PRODUCT_TYPE_ID_EIGHT_JSON_OBJECT_STRING,
                 $PRODUCT_TYPE_ID_EIGHTEEN_JSON_OBJECT_STRING
             ]
         """.trimIndent()

--- a/libsource/src/test/java/com/virtusize/libsource/fixtures/ProductFixtures.kt
+++ b/libsource/src/test/java/com/virtusize/libsource/fixtures/ProductFixtures.kt
@@ -1,5 +1,6 @@
 package com.virtusize.libsource.fixtures
 
+import com.virtusize.libsource.data.parsers.ProductTypeJsonParser
 import com.virtusize.libsource.data.remote.*
 import org.json.JSONArray
 import org.json.JSONObject
@@ -246,6 +247,16 @@ internal object ProductFixtures {
         """.trimIndent()
     )
 
+    fun productTypes() = run {
+        val productTypes: MutableList<ProductType> = mutableListOf()
+        for (i in 0 until PRODUCT_TYPE_JSON_ARRAY.length()) {
+            ProductTypeJsonParser().parse(PRODUCT_TYPE_JSON_ARRAY[i] as JSONObject)?.let {
+                productTypes.add(it)
+            }
+        }
+        productTypes
+    }
+
     fun storeProduct(
         productType: Int = 8,
         sizeList: List<ProductSize> = mutableListOf(
@@ -432,7 +443,7 @@ internal object ProductFixtures {
         """.trimIndent()
     )
 
-    val USER_PRODUCT_ONE_JSON_STRING =
+    private val USER_PRODUCT_ONE_JSON_STRING =
         """
             {
                 "id": 123456,
@@ -462,7 +473,7 @@ internal object ProductFixtures {
             }
       """.trimIndent()
 
-    val USER_PRODUCT_TWO_JSON_STRING =
+    private val USER_PRODUCT_TWO_JSON_STRING =
         """
             {
                 "id": 654321,

--- a/libsource/src/test/java/com/virtusize/libsource/fixtures/ProductFixtures.kt
+++ b/libsource/src/test/java/com/virtusize/libsource/fixtures/ProductFixtures.kt
@@ -169,7 +169,7 @@ internal object ProductFixtures {
 
     fun storeProduct(
         productType: Int = 8,
-        sizes: List<ProductSize> = mutableListOf(
+        sizeList: List<ProductSize> = mutableListOf(
             ProductSize(
                 "38",
                 mutableSetOf(
@@ -186,11 +186,20 @@ internal object ProductFixtures {
                     Measurement("sleeve", 825)
                 )
             )
-        )
-    ) : Product {
+        ),
+        brand: String = "Virtusize",
+        modelInfo: Map<String, Any>? = mutableMapOf(
+            "hip" to 85,
+            "size" to "38",
+            "waist" to 56,
+            "bust" to 78,
+            "height" to 165
+        ),
+        gender: String? = "female"
+    ): Product {
         return Product(
             7110384,
-            sizes,
+            sizeList,
             "694",
             productType,
             "Test Product Name",
@@ -200,10 +209,16 @@ internal object ProductFixtures {
             StoreProductMeta(
                 1,
                 StoreProductAdditionalInfo(
+                    brand,
+                    gender,
+                    sizeList.toMutableSet(),
+                    modelInfo,
                     "regular",
                     "fashionable",
                     BrandSizing("large", false)
-                )
+                ),
+                brand,
+                gender
             )
         )
     }

--- a/libsource/src/test/java/com/virtusize/libsource/fixtures/TestFixtures.kt
+++ b/libsource/src/test/java/com/virtusize/libsource/fixtures/TestFixtures.kt
@@ -222,5 +222,36 @@ internal object TestFixtures {
                 }
             """.trimIndent()
     )
+
+    val userBodyProfile = UserBodyProfile(
+        "female",
+        32,
+        1630,
+        "50.00",
+        mutableSetOf(
+            Measurement("hip", 830),
+            Measurement("hip", 830),
+            Measurement("bust", 755),
+            Measurement("neck", 300),
+            Measurement("rise", 215),
+            Measurement("bicep", 220),
+            Measurement("thigh", 480),
+            Measurement("waist", 630),
+            Measurement("inseam", 700),
+            Measurement("sleeve", 720),
+            Measurement("shoulder", 370),
+            Measurement("hipWidth", 300),
+            Measurement("bustWidth", 245),
+            Measurement("hipHeight", 750),
+            Measurement("headHeight", 215),
+            Measurement("kneeHeight", 395),
+            Measurement("waistWidth", 225),
+            Measurement("waistHeight", 920),
+            Measurement("armpitHeight", 1130),
+            Measurement("sleeveLength", 520),
+            Measurement("shoulderWidth", 340),
+            Measurement("shoulderHeight", 1240)
+        )
+    )
 }
 

--- a/libsource/src/test/java/com/virtusize/libsource/network/VirtusizeApiTest.kt
+++ b/libsource/src/test/java/com/virtusize/libsource/network/VirtusizeApiTest.kt
@@ -8,6 +8,7 @@ import com.google.common.truth.Truth.assertThat
 import com.virtusize.libsource.fixtures.TestFixtures
 import com.virtusize.libsource.data.local.*
 import com.virtusize.libsource.data.parsers.JsonUtils
+import com.virtusize.libsource.fixtures.ProductFixtures
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -227,6 +228,152 @@ class VirtusizeApiTest {
         val expectedUrl = "https://staging.virtusize.com/a/api/v3/user-body-measurements"
 
         val expectedApiRequest = ApiRequest(expectedUrl, HttpMethod.GET, mutableMapOf(), true)
+
+        assertThat(actualApiRequest).isEqualTo(expectedApiRequest)
+    }
+
+    @Test
+    fun getSize_shouldReturnExpectedApiRequest() {
+        val actualApiRequest = VirtusizeApi.getSize(
+            ProductFixtures.productTypes(),
+            ProductFixtures.storeProduct(),
+            TestFixtures.userBodyProfile
+        )
+
+        val expectedUrl = "https://services.virtusize.com/stg/ds-functions/size-rec/get-size"
+
+        val expectedParamsMap = mutableMapOf(
+            "user_gender" to "female",
+            "item_sizes_orig" to mutableMapOf(
+                "38" to mutableMapOf(
+                    "bust" to 660,
+                    "sleeve" to 845,
+                    "height" to 760
+                ),
+                "36" to mutableMapOf(
+                    "bust" to 645,
+                    "sleeve" to 825,
+                    "height" to 750
+                )
+            ),
+            "product_type" to "jacket",
+            "additional_info" to mutableMapOf(
+                "fit" to "regular",
+                "sizes" to mutableMapOf(
+                    "38" to mutableMapOf(
+                        "bust" to 660,
+                        "sleeve" to 845,
+                        "height" to 760
+                    ),
+                    "36" to mutableMapOf(
+                        "bust" to 645,
+                        "sleeve" to 825,
+                        "height" to 750
+                    )
+                ),
+                "gender" to "female",
+                "brand" to "Virtusize",
+                "model_info" to mutableMapOf(
+                    "waist" to 56,
+                    "bust" to 78,
+                    "size" to "38",
+                    "hip" to 85,
+                    "height" to 165
+                )
+            ),
+            "body_data" to mutableMapOf(
+                "waistWidth" to mutableMapOf(
+                    "value" to 225,
+                    "predicted" to true
+                ),
+                "chest" to mutableMapOf(
+                    "value" to 755,
+                    "predicted" to true
+                ),
+                "bustWidth" to mutableMapOf(
+                    "value" to 245,
+                    "predicted" to true
+                ),
+                "thigh" to mutableMapOf(
+                    "value" to 480,
+                    "predicted" to true
+                ),
+                "shoulderWidth" to mutableMapOf(
+                    "value" to 340,
+                    "predicted" to true
+                ),
+                "hipHeight" to mutableMapOf(
+                    "value" to 750,
+                    "predicted" to true
+                ),
+                "kneeHeight" to mutableMapOf(
+                    "value" to 395,
+                    "predicted" to true
+                ),
+                "neck" to mutableMapOf(
+                    "value" to 300,
+                    "predicted" to true
+                ),
+                "waistHeight" to mutableMapOf(
+                    "value" to 920,
+                    "predicted" to true
+                ),
+                "hip" to mutableMapOf(
+                    "value" to 830,
+                    "predicted" to true
+                ),
+                "armpitHeight" to mutableMapOf(
+                    "value" to 1130,
+                    "predicted" to true
+                ),
+                "bicep" to mutableMapOf(
+                    "value" to 220,
+                    "predicted" to true
+                ),
+                "inseam" to mutableMapOf(
+                    "value" to 700,
+                    "predicted" to true
+                ),
+                "headHeight" to mutableMapOf(
+                    "value" to 215,
+                    "predicted" to true
+                ),
+                "hipWidth" to mutableMapOf(
+                    "value" to 300,
+                    "predicted" to true
+                ),
+                "sleeve" to mutableMapOf(
+                    "value" to 720,
+                    "predicted" to true
+                ),
+                "bust" to mutableMapOf(
+                    "value" to 755,
+                    "predicted" to true
+                ),
+                "waist" to mutableMapOf(
+                    "value" to 630,
+                    "predicted" to true
+                ),
+                "sleeveLength" to mutableMapOf(
+                    "value" to 520,
+                    "predicted" to true
+                ),
+                "rise" to mutableMapOf(
+                    "value" to 215,
+                    "predicted" to true
+                ),
+                "shoulder" to mutableMapOf(
+                    "value" to 370,
+                    "predicted" to true
+                ),
+                "shoulderHeight" to mutableMapOf(
+                    "value" to 1240,
+                    "predicted" to true
+                )
+            )
+        )
+
+        val expectedApiRequest = ApiRequest(expectedUrl, HttpMethod.POST, expectedParamsMap)
 
         assertThat(actualApiRequest).isEqualTo(expectedApiRequest)
     }


### PR DESCRIPTION
## Summary
- [x] Add the class **BodyProfileRecommendedSizeParams** to create the request body for endpoint `get-size`
- [x] Add the function **getSize** in VirtusizeApi.kt to create the ApiRequest for endpoint `get-size`
- [x] Add the classes **BodyProfileRecommendedSize** and **BodyProfileRecommendedSizeJsonParser** to handle the API response from `get-size`
- [x] Add the function **getUserBodyRecommendedSize** in Virtusize.kt to get the recommended size