### PR TITLE
Feature: Update the event API URL

### DIFF
--- a/libsource/src/main/java/com/virtusize/libsource/data/local/VirtusizeEnvironment.kt
+++ b/libsource/src/main/java/com/virtusize/libsource/data/local/VirtusizeEnvironment.kt
@@ -26,6 +26,19 @@ fun VirtusizeEnvironment.apiUrl(): String {
 }
 
 /**
+ * Gets the event API URL corresponding to the Virtusize Environment
+ * @return A String value of the event API URL
+ */
+fun VirtusizeEnvironment.eventApiUrl(): String {
+    return when(this) {
+        STAGING -> "https://events.staging.virtusize.jp"
+        JAPAN -> "https://events.virtusize.jp"
+        GLOBAL -> "https://events.virtusize.com"
+        KOREA -> "https://events.virtusize.kr"
+    }
+}
+
+/**
  * Gets the URL for the API endpoint Product Data Check corresponding to the Virtusize Environment
  * @return A String value of the URL for the API endpoint Product Data Check
  */

--- a/libsource/src/main/java/com/virtusize/libsource/network/VirtusizeApi.kt
+++ b/libsource/src/main/java/com/virtusize/libsource/network/VirtusizeApi.kt
@@ -114,7 +114,7 @@ internal object VirtusizeApi {
         screenResolution: String,
         versionCode: Int
     ): ApiRequest {
-        val url = Uri.parse(environment.apiUrl() + VirtusizeEndpoint.Events.getPath())
+        val url = Uri.parse(environment.eventApiUrl())
             .buildUpon()
             .build()
             .toString()

--- a/libsource/src/main/java/com/virtusize/libsource/network/VirtusizeEndpoint.kt
+++ b/libsource/src/main/java/com/virtusize/libsource/network/VirtusizeEndpoint.kt
@@ -7,7 +7,6 @@ internal enum class VirtusizeEndpoint {
     ProductCheck,
     Virtusize,
     ProductMetaDataHints,
-    Events,
     Orders,
     StoreViewApiKey
 }
@@ -26,9 +25,6 @@ internal fun VirtusizeEndpoint.getPath(): String {
          }
          VirtusizeEndpoint.ProductMetaDataHints -> {
              "/rest-api/v1/product-meta-data-hints"
-         }
-         VirtusizeEndpoint.Events -> {
-             "/a/api/v3/events"
          }
          VirtusizeEndpoint.Orders -> {
              "/a/api/v3/orders"

--- a/libsource/src/test/java/com/virtusize/libsource/VirtusizeTest.kt
+++ b/libsource/src/test/java/com/virtusize/libsource/VirtusizeTest.kt
@@ -147,14 +147,7 @@ class VirtusizeTest {
     fun testSendProductImageToBackend_whenFailed_hasExpectedErrorInfo() = runBlocking {
         virtusize.setHTTPURLConnection(MockHttpURLConnection(
             mockURL,
-            MockedResponse(
-                500,
-                ("<!DOCTYPE HTML PUBLIC \"-//W3C//DTD HTML 3.2 Final//EN\">\n<title>500 Internal Server Error</title>\n" +
-                        "<h1>Internal Server Error</h1>\n" +
-                        "<p>The server encountered an internal error and was unable to complete your request.  " +
-                        "Either the server is overloaded or there is an error in the application.</p>").byteInputStream(),
-                "Internal Server Error"
-            )
+            MockedResponse(500, INTERNAL_SERVER_ERROR_RESPONSE.byteInputStream(), null)
         )
         )
         virtusize.sendProductImageToBackend(TestFixtures.VIRTUSIZE_PRODUCT, object: SuccessResponseHandler {
@@ -166,7 +159,7 @@ class VirtusizeTest {
         })
 
         assertThat(actualError?.code).isEqualTo(500)
-        assertThat(actualError?.message).isEqualTo("Internal Server Error")
+        assertThat(actualError?.message).contains(INTERNAL_SERVER_ERROR_RESPONSE)
         assertThat(actualError?.type).isEqualTo(VirtusizeErrorType.NetworkError)
     }
 
@@ -276,5 +269,12 @@ class VirtusizeTest {
         )
 
         assertThat(isSuccessful).isTrue()
+    }
+
+    companion object {
+        private const val INTERNAL_SERVER_ERROR_RESPONSE = "<!DOCTYPE HTML PUBLIC \"-//W3C//DTD HTML 3.2 Final//EN\">\n<title>500 Internal Server Error</title>\n" +
+                "<h1>Internal Server Error</h1>\n" +
+                "<p>The server encountered an internal error and was unable to complete your request.  " +
+                "Either the server is overloaded or there is an error in the application.</p>"
     }
 }

--- a/libsource/src/test/java/com/virtusize/libsource/network/VirtusizeApiTest.kt
+++ b/libsource/src/test/java/com/virtusize/libsource/network/VirtusizeApiTest.kt
@@ -122,7 +122,7 @@ class VirtusizeApiTest {
             expectedParams.plus(JsonUtils.jsonObjectToMap(it))
         }
 
-        assertThat(actualApiRequest.url).isEqualTo("https://staging.virtusize.com/a/api/v3/events")
+        assertThat(actualApiRequest.url).isEqualTo("https://events.staging.virtusize.jp")
         assertThat(actualApiRequest.method).isEquivalentAccordingToCompareTo(HttpMethod.POST)
         assertThat(actualApiRequest.params).containsExactlyEntriesIn(expectedParams)
     }


### PR DESCRIPTION
## Summary
- [x] Update the event API URL to "https://events.staging.virtusize.jp" for staging and "https://events.virtusize.{env}" for production
- [x] Fix a unit test about the 500 response