### PR TITLE
Fix: the wrong InPage message when a user logs out

### DIFF
--- a/libsource/src/main/java/com/virtusize/libsource/Virtusize.kt
+++ b/libsource/src/main/java/com/virtusize/libsource/Virtusize.kt
@@ -39,7 +39,9 @@ class Virtusize(
             when (event.name) {
                 VirtusizeEvents.UserOpenedWidget.getEventName() -> {
                     CoroutineScope(Main).launch {
-                        virtusizeRepository.fetchDataForInPageRecommendation(false)
+                        virtusizeRepository.fetchDataForInPageRecommendation(
+                            shouldUpdateUserProducts = false
+                        )
                     }
                 }
                 VirtusizeEvents.UserAuthData.getEventName() -> {
@@ -51,7 +53,10 @@ class Virtusize(
                     // Filters userProducts by the selected product ID to get userProductRecommendedSize
                     val userProductId = event.data?.optInt("userProductId")
                     CoroutineScope(Main).launch {
-                        virtusizeRepository.fetchDataForInPageRecommendation(false, userProductId)
+                        virtusizeRepository.fetchDataForInPageRecommendation(
+                            shouldUpdateUserProducts = false,
+                            selectedUserProductId = userProductId
+                        )
                         virtusizeRepository.switchInPageRecommendation(SizeRecommendationType.compareProduct)
                     }
                 }
@@ -60,7 +65,10 @@ class Virtusize(
                     // and then filters userProducts by the selected product ID to get userProductRecommendedSize
                     val userProductId = event.data?.optInt("userProductId")
                     CoroutineScope(Main).launch {
-                        virtusizeRepository.fetchDataForInPageRecommendation(true, userProductId)
+                        virtusizeRepository.fetchDataForInPageRecommendation(
+                            shouldUpdateUserProducts = true,
+                            selectedUserProductId = userProductId
+                        )
                         virtusizeRepository.switchInPageRecommendation(SizeRecommendationType.compareProduct)
                     }
                 }
@@ -96,7 +104,9 @@ class Virtusize(
                     CoroutineScope(Main).launch {
                         virtusizeRepository.clearUserData()
                         virtusizeRepository.updateUserSession()
-                        virtusizeRepository.fetchDataForInPageRecommendation()
+                        virtusizeRepository.fetchDataForInPageRecommendation(
+                            shouldUpdateUserProducts = false
+                        )
                         virtusizeRepository.switchInPageRecommendation()
                     }
                 }

--- a/libsource/src/main/java/com/virtusize/libsource/VirtusizeRepository.kt
+++ b/libsource/src/main/java/com/virtusize/libsource/VirtusizeRepository.kt
@@ -194,7 +194,8 @@ internal class VirtusizeRepository(
     /**
      * Clear user session and the data related to size recommendations
      */
-    internal fun clearUserData() {
+    internal suspend fun clearUserData() {
+        virtusizeAPIService.deleteUser()
         sharedPreferencesHelper.storeAuthToken("")
 
         userProducts = null

--- a/libsource/src/main/java/com/virtusize/libsource/network/VirtusizeAPIService.kt
+++ b/libsource/src/main/java/com/virtusize/libsource/network/VirtusizeAPIService.kt
@@ -226,6 +226,10 @@ internal class VirtusizeAPIService(private var context: Context, private var mes
             .execute(apiRequest)
     }
 
+    /**
+     * Gets the API response for deleting a user
+     * @return the [VirtusizeApiResponse]
+     */
     internal suspend fun deleteUser(): VirtusizeApiResponse<Any> = withContext(
         Dispatchers.IO
     ) {

--- a/libsource/src/main/java/com/virtusize/libsource/network/VirtusizeAPIService.kt
+++ b/libsource/src/main/java/com/virtusize/libsource/network/VirtusizeAPIService.kt
@@ -226,6 +226,18 @@ internal class VirtusizeAPIService(private var context: Context, private var mes
             .execute(apiRequest)
     }
 
+    internal suspend fun deleteUser(): VirtusizeApiResponse<Any> = withContext(
+        Dispatchers.IO
+    ) {
+        val apiRequest = VirtusizeApi.deleteUser()
+        VirtusizeApiTask(
+            httpURLConnection,
+            sharedPreferencesHelper,
+            messageHandler
+        )
+            .execute(apiRequest)
+    }
+
     /**
      * Gets the API response for retrieving a list of user products
      * @return the [VirtusizeApiResponse] with the list of [Product]

--- a/libsource/src/main/java/com/virtusize/libsource/network/VirtusizeApi.kt
+++ b/libsource/src/main/java/com/virtusize/libsource/network/VirtusizeApi.kt
@@ -272,6 +272,10 @@ internal object VirtusizeApi {
         return ApiRequest(url, HttpMethod.POST)
     }
 
+    /**
+     * Deletes a user
+     * @see ApiRequest
+     */
     fun deleteUser(): ApiRequest {
         val url = Uri.parse(environment.defaultApiUrl() + VirtusizeEndpoint.User.getPath())
             .buildUpon()

--- a/libsource/src/main/java/com/virtusize/libsource/network/VirtusizeApi.kt
+++ b/libsource/src/main/java/com/virtusize/libsource/network/VirtusizeApi.kt
@@ -14,7 +14,8 @@ import com.virtusize.libsource.data.remote.UserBodyProfile
  */
 internal enum class HttpMethod {
     GET,
-    POST
+    POST,
+    DELETE
 }
 
 /**
@@ -269,6 +270,14 @@ internal object VirtusizeApi {
             .build()
             .toString()
         return ApiRequest(url, HttpMethod.POST)
+    }
+
+    fun deleteUser(): ApiRequest {
+        val url = Uri.parse(environment.defaultApiUrl() + VirtusizeEndpoint.User.getPath())
+            .buildUpon()
+            .build()
+            .toString()
+        return ApiRequest(url, HttpMethod.DELETE)
     }
 
     /**

--- a/libsource/src/main/java/com/virtusize/libsource/network/VirtusizeApiTask.kt
+++ b/libsource/src/main/java/com/virtusize/libsource/network/VirtusizeApiTask.kt
@@ -179,7 +179,7 @@ internal class VirtusizeApiTask(
                     }
                 }
             }
-            if(isErrorStream && result == null) {
+            if(result == null) {
                 result = streamString
             }
         }

--- a/libsource/src/main/java/com/virtusize/libsource/network/VirtusizeEndpoint.kt
+++ b/libsource/src/main/java/com/virtusize/libsource/network/VirtusizeEndpoint.kt
@@ -15,6 +15,7 @@ internal enum class VirtusizeEndpoint {
     StoreProducts,
     ProductType,
     Sessions,
+    User,
     UserProducts,
     UserBodyMeasurements,
     I18N
@@ -52,6 +53,9 @@ internal fun VirtusizeEndpoint.getPath(env: VirtusizeEnvironment? = null): Strin
          }
          VirtusizeEndpoint.Sessions -> {
              "/a/api/v3/sessions"
+         }
+         VirtusizeEndpoint.User -> {
+             "/a/api/v3/users/me"
          }
          VirtusizeEndpoint.UserProducts -> {
              "/a/api/v3/user-products"

--- a/libsource/src/test/java/com/virtusize/libsource/network/VirtusizeAPIServiceTest.kt
+++ b/libsource/src/test/java/com/virtusize/libsource/network/VirtusizeAPIServiceTest.kt
@@ -288,6 +288,18 @@ class VirtusizeAPIServiceTest {
     }
 
     @Test
+    fun testGetDeleteUserResponse() = runBlocking {
+        val expectedDeleteUserJsonResponse= "{\"wardrobe(s) deleted from DB\":1,\"user product(s) deleted from DB\":1,\"duration\":0.04}"
+        virtusizeAPIService.setHTTPURLConnection(MockHttpsURLConnection(
+            mockURL,
+            MockedResponse(200, expectedDeleteUserJsonResponse.byteInputStream())
+        ))
+
+        val actualSuccessfulResponse = virtusizeAPIService.deleteUser().successData
+        assertThat(actualSuccessfulResponse).isEqualTo(expectedDeleteUserJsonResponse)
+    }
+
+    @Test
     fun testGetUserProductsResponse_userHasItemsInTheWardrobe_shouldReturnExpectedUserProducts() = runBlocking {
         virtusizeAPIService.setHTTPURLConnection(MockHttpsURLConnection(
             mockURL,


### PR DESCRIPTION
## Description
When a user logs out of Aoyama, the SDK will make an API call to `/user-products` to re-fetch user items. The product list is expected to be empty from the server, but in fact, the product list includes the items that the user has created before they log in and then log out, which causes InPage does not display "Find the right size ..." when a user logs out.

## Summary
- [x] Make an API call to DELETE /users/me after a user logs out to delete the anonymous user with items.
- [x] Disable fetching user products when a user logs out by passing shouldUpdateUserProducts = false to the function virtusizeRepository.fetchDataForInPageRecommendation