### PR TITLE
Fix: the crash when a user's body profile is null

### DIFF
--- a/libsource/src/main/java/com/virtusize/libsource/VirtusizeRepository.kt
+++ b/libsource/src/main/java/com/virtusize/libsource/VirtusizeRepository.kt
@@ -84,7 +84,7 @@ internal class VirtusizeRepository(
                     }
                     presenter?.onValidProductId(productDataId)
                 } else {
-                    presenter?.hasInPageError(VirtusizeErrorType.InvalidProduct.virtusizeError(virtusizeProduct.externalId))
+                    presenter?.hasInPageError(VirtusizeErrorType.InvalidProduct.virtusizeError(extraMessage = virtusizeProduct.externalId))
                 }
             }
         } else {
@@ -276,7 +276,7 @@ internal class VirtusizeRepository(
             sharedPreferencesHelper.storeBrowserId(userAutoData?.bid)
             sharedPreferencesHelper.storeAuthToken(userAutoData?.auth)
         } catch (e: JSONException) {
-            messageHandler.onError(VirtusizeErrorType.JsonParsingError.virtusizeError(e.localizedMessage))
+            messageHandler.onError(VirtusizeErrorType.JsonParsingError.virtusizeError(extraMessage = e.localizedMessage))
         }
     }
 }

--- a/libsource/src/main/java/com/virtusize/libsource/data/local/VirtusizeErrorType.kt
+++ b/libsource/src/main/java/com/virtusize/libsource/data/local/VirtusizeErrorType.kt
@@ -28,7 +28,7 @@ enum class VirtusizeErrorType {
 fun VirtusizeErrorType.code(): Int? {
     return when(this) {
         VirtusizeErrorType.ApiKeyNullOrInvalid -> HttpURLConnection.HTTP_FORBIDDEN
-        VirtusizeErrorType.InvalidProduct -> HttpURLConnection.HTTP_NOT_FOUND
+        VirtusizeErrorType.InvalidProduct, VirtusizeErrorType.UnParsedProduct, VirtusizeErrorType.WardrobeNotFound -> HttpURLConnection.HTTP_NOT_FOUND
         else -> null
     }
 }
@@ -56,10 +56,12 @@ fun VirtusizeErrorType.message(extraMessage: String? = null): String {
 
 /**
  * Returns the [VirtusizeError] corresponding to the VirtusizeErrorType
+ * @param code an error code
+ * @param extraMessage an extra error message specific to this error type
  * @return the [VirtusizeError] for the VirtusizeErrorType
  */
-internal fun VirtusizeErrorType.virtusizeError(extraMessage: String? = null): VirtusizeError {
-    return VirtusizeError(this, this.code(), this.message(extraMessage))
+internal fun VirtusizeErrorType.virtusizeError(code: Int? = null, extraMessage: String? = null): VirtusizeError {
+    return VirtusizeError(this, code ?: this.code(), this.message(extraMessage))
 }
 
 /**

--- a/libsource/src/main/java/com/virtusize/libsource/data/local/VirtusizeErrorType.kt
+++ b/libsource/src/main/java/com/virtusize/libsource/data/local/VirtusizeErrorType.kt
@@ -15,7 +15,7 @@ enum class VirtusizeErrorType {
     NullProduct,
     UnParsedProduct,
     InvalidProduct,
-    NetworkError,
+    APIError,
     JsonParsingError,
     WardrobeNotFound,
     PrivacyLinkNotOpen
@@ -47,7 +47,7 @@ fun VirtusizeErrorType.message(extraMessage: String? = null): String {
         VirtusizeErrorType.NullProduct -> "The store product is null. Please set up your store product"
         VirtusizeErrorType.InvalidProduct -> "The store product $extraMessage is not valid in the Virtusize server"
         VirtusizeErrorType.UnParsedProduct -> "The store product $extraMessage is not parsed in the Virtusize server yet"
-        VirtusizeErrorType.NetworkError -> "Virtusize API error: $extraMessage"
+        VirtusizeErrorType.APIError -> "Virtusize API error: $extraMessage"
         VirtusizeErrorType.JsonParsingError -> "JSON response parsing error: $extraMessage"
         VirtusizeErrorType.WardrobeNotFound -> "The user's wardrobe hasn't been created in the Virtusize server yet"
         VirtusizeErrorType.PrivacyLinkNotOpen -> "The privacy link can not be open. The error is: $extraMessage"

--- a/libsource/src/main/java/com/virtusize/libsource/network/VirtusizeApiTask.kt
+++ b/libsource/src/main/java/com/virtusize/libsource/network/VirtusizeApiTask.kt
@@ -49,6 +49,7 @@ internal class VirtusizeApiTask(
 
     /**
      * Sets up the JSON parser for converting the JSON response to a given type of Java object
+     * @return the [VirtusizeApiTask] with the JSON parser set up
      */
     fun setJsonParser(jsonParser: VirtusizeJsonParser<Any>?): VirtusizeApiTask {
         this.jsonParser = jsonParser
@@ -58,6 +59,7 @@ internal class VirtusizeApiTask(
     /**
      * Executes the API request and returns the response
      * @param apiRequest [ApiRequest]
+     * @return VirtusizeApiResponse of the generic type T
      */
     fun <T> execute(apiRequest: ApiRequest): VirtusizeApiResponse<T> {
         var urlConnection: HttpsURLConnection? = urlConnection
@@ -220,6 +222,7 @@ internal class VirtusizeApiTask(
      * Parses the string of an input stream to an object
      * @param apiRequestUrl the API request URL
      * @param streamString the string of the input stream
+     * @return either the data object that is converted from streamString or null
      */
     private fun parseStringToObject(
         apiRequestUrl: String? = null,
@@ -243,6 +246,7 @@ internal class VirtusizeApiTask(
     /**
      * Check if the response of the API request is a JSON array
      * @param apiRequestUrl The input stream of bytes
+     * @return the boolean value to tell whether the response of the apiRequestUrl is a JSON array.
      */
     private fun responseIsJsonArray(apiRequestUrl: String): Boolean {
         return apiRequestUrl.contains(VirtusizeEndpoint.ProductType.getPath())
@@ -252,6 +256,7 @@ internal class VirtusizeApiTask(
     /**
      * Returns the contents of an [InputStream] as a String.
      * @param inputStream The input stream of bytes
+     * @return the string from scanning through the inputStream
      */
     private fun readInputStreamAsString(inputStream: InputStream): String? {
         val scanner: Scanner = Scanner(inputStream).useDelimiter("\\A")
@@ -263,6 +268,7 @@ internal class VirtusizeApiTask(
      * @param urlPath The endpoint path of an API request
      * @param responseCode The response code of an API request
      * @param response The response from an API request
+     * @return the network related [VirtusizeError]
      */
     private fun virtusizeAPIError(
         urlPath: String?,

--- a/libsource/src/main/java/com/virtusize/libsource/network/VirtusizeApiTask.kt
+++ b/libsource/src/main/java/com/virtusize/libsource/network/VirtusizeApiTask.kt
@@ -75,7 +75,10 @@ internal class VirtusizeApiTask(
 
                     // Set the access token in the header if the request needs authentication
                     if (apiRequest.authorization) {
-                        setRequestProperty(HEADER_AUTHORIZATION, "Token ${sharedPreferencesHelper.getAccessToken()}")
+                        setRequestProperty(
+                            HEADER_AUTHORIZATION,
+                            "Token ${sharedPreferencesHelper.getAccessToken()}"
+                        )
                     }
 
                     // Send the POST request
@@ -84,7 +87,7 @@ internal class VirtusizeApiTask(
                         setRequestProperty(HEADER_CONTENT_TYPE, "application/json")
 
                         // Set up the request header for the sessions API
-                        if(apiRequest.url.contains(VirtusizeEndpoint.Sessions.getPath())) {
+                        if (apiRequest.url.contains(VirtusizeEndpoint.Sessions.getPath())) {
                             sharedPreferencesHelper.getAuthToken()?.let {
                                 setRequestProperty(HEADER_AUTH, it)
                                 setRequestProperty(HEADER_COOKIE, "")
@@ -109,7 +112,11 @@ internal class VirtusizeApiTask(
                         val response = parseInputStreamToObject(apiRequest.url, inputStream)
                         VirtusizeApiResponse.Success(response) as VirtusizeApiResponse<T>
                     } catch (e: JSONException) {
-                        VirtusizeApiResponse.Error(VirtusizeErrorType.JsonParsingError.virtusizeError("${apiRequest.url} ${e.localizedMessage}"))
+                        VirtusizeApiResponse.Error(
+                            VirtusizeErrorType.JsonParsingError.virtusizeError(
+                                "${apiRequest.url} ${e.localizedMessage}"
+                            )
+                        )
                     }
                 }
                 // If the request fails but it has a error response, then read the error stream and parse the response.
@@ -124,20 +131,44 @@ internal class VirtusizeApiTask(
                         HttpURLConnection.HTTP_NOT_FOUND -> {
                             // If the product cannot be found in the Virtusize Server
                             if (response is ProductCheck) {
-                                return VirtusizeApiResponse.Error(VirtusizeErrorType.UnParsedProduct.virtusizeError(response.productId))
+                                return VirtusizeApiResponse.Error(
+                                    VirtusizeErrorType.UnParsedProduct.virtusizeError(
+                                        response.productId
+                                    )
+                                )
                             }
-                            virtusizeNetworkError(urlConnection.url?.path, urlConnection.responseCode,response ?: urlConnection.responseMessage)
+                            virtusizeNetworkError(
+                                urlConnection.url?.path,
+                                urlConnection.responseCode,
+                                response ?: urlConnection.responseMessage
+                            )
                         }
                         else -> {
-                            virtusizeNetworkError(urlConnection.url?.path, urlConnection.responseCode,response ?: urlConnection.responseMessage)
+                            virtusizeNetworkError(
+                                urlConnection.url?.path,
+                                urlConnection.responseCode,
+                                response ?: urlConnection.responseMessage
+                            )
                         }
                     }
                     return VirtusizeApiResponse.Error(error)
                 }
-                else -> return VirtusizeApiResponse.Error(virtusizeNetworkError(urlConnection.url?.path, urlConnection.responseCode, urlConnection.responseMessage))
+                else -> return VirtusizeApiResponse.Error(
+                    virtusizeNetworkError(
+                        urlConnection.url?.path,
+                        urlConnection.responseCode,
+                        urlConnection.responseMessage
+                    )
+                )
             }
         } catch (e: IOException) {
-            return VirtusizeApiResponse.Error(virtusizeNetworkError(urlConnection?.url?.path, null, e.localizedMessage))
+            return VirtusizeApiResponse.Error(
+                virtusizeNetworkError(
+                    urlConnection?.url?.path,
+                    null,
+                    e.localizedMessage
+                )
+            )
         } finally {
             urlConnection?.disconnect()
             inputStream?.close()
@@ -156,13 +187,13 @@ internal class VirtusizeApiTask(
         inputStream: InputStream
     ): Any? {
         var result: Any? = null
-            readInputStreamAsString(inputStream)?.let { streamString ->
-                try {
-                    result = parseStringToObject(apiRequestUrl, streamString)
-                } catch (e: JSONException) {
-                    messageHandler?.onError(VirtusizeErrorType.JsonParsingError.virtusizeError(e.localizedMessage))
-                }
+        readInputStreamAsString(inputStream)?.let { streamString ->
+            try {
+                result = parseStringToObject(apiRequestUrl, streamString)
+            } catch (e: JSONException) {
+                messageHandler?.onError(VirtusizeErrorType.JsonParsingError.virtusizeError(e.localizedMessage))
             }
+        }
         return result
     }
 
@@ -177,8 +208,8 @@ internal class VirtusizeApiTask(
         var result: Any? = null
         readInputStreamAsString(errorStream)?.let { streamString ->
             result = try {
-                parseStringToObject(streamString=streamString)
-            } catch (e: JSONException)  {
+                parseStringToObject(streamString = streamString)
+            } catch (e: JSONException) {
                 streamString
             }
         }
@@ -233,7 +264,15 @@ internal class VirtusizeApiTask(
      * @param responseCode The response code of an API request
      * @param response The response from an API request
      */
-    private fun virtusizeNetworkError(urlPath: String?, responseCode: Int?, response: Any?): VirtusizeError {
-        return VirtusizeError(VirtusizeErrorType.NetworkError, responseCode, "$urlPath - ${response?.toString()}")
+    private fun virtusizeNetworkError(
+        urlPath: String?,
+        responseCode: Int?,
+        response: Any?
+    ): VirtusizeError {
+        return VirtusizeError(
+            VirtusizeErrorType.NetworkError,
+            responseCode,
+            "$urlPath - ${response?.toString()}"
+        )
     }
 }

--- a/libsource/src/main/java/com/virtusize/libsource/network/VirtusizeApiTask.kt
+++ b/libsource/src/main/java/com/virtusize/libsource/network/VirtusizeApiTask.kt
@@ -137,14 +137,14 @@ internal class VirtusizeApiTask(
                                     )
                                 )
                             }
-                            virtusizeNetworkError(
+                            virtusizeAPIError(
                                 urlConnection.url?.path,
                                 urlConnection.responseCode,
                                 response ?: urlConnection.responseMessage
                             )
                         }
                         else -> {
-                            virtusizeNetworkError(
+                            virtusizeAPIError(
                                 urlConnection.url?.path,
                                 urlConnection.responseCode,
                                 response ?: urlConnection.responseMessage
@@ -154,7 +154,7 @@ internal class VirtusizeApiTask(
                     return VirtusizeApiResponse.Error(error)
                 }
                 else -> return VirtusizeApiResponse.Error(
-                    virtusizeNetworkError(
+                    virtusizeAPIError(
                         urlConnection.url?.path,
                         urlConnection.responseCode,
                         urlConnection.responseMessage
@@ -163,7 +163,7 @@ internal class VirtusizeApiTask(
             }
         } catch (e: IOException) {
             return VirtusizeApiResponse.Error(
-                virtusizeNetworkError(
+                virtusizeAPIError(
                     urlConnection?.url?.path,
                     null,
                     e.localizedMessage
@@ -180,7 +180,7 @@ internal class VirtusizeApiTask(
      * Parses the contents of an inputStream of the type [InputStream]
      * @param apiRequestUrl the API request URL
      * @param inputStream the input stream of bytes
-     * @return either an object that contains the contents of an inputStream or null
+     * @return either the object that contains the contents of an inputStream or null
      */
     private fun parseInputStreamToObject(
         apiRequestUrl: String? = null,
@@ -250,7 +250,7 @@ internal class VirtusizeApiTask(
     }
 
     /**
-     * Returns the contents of an InputStream as a String.
+     * Returns the contents of an [InputStream] as a String.
      * @param inputStream The input stream of bytes
      */
     private fun readInputStreamAsString(inputStream: InputStream): String? {
@@ -259,18 +259,18 @@ internal class VirtusizeApiTask(
     }
 
     /**
-     * Returns the VirtusizeError that is associated with an API error
+     * Returns the [VirtusizeError] that is associated with an API error
      * @param urlPath The endpoint path of an API request
      * @param responseCode The response code of an API request
      * @param response The response from an API request
      */
-    private fun virtusizeNetworkError(
+    private fun virtusizeAPIError(
         urlPath: String?,
         responseCode: Int?,
         response: Any?
     ): VirtusizeError {
         return VirtusizeError(
-            VirtusizeErrorType.NetworkError,
+            VirtusizeErrorType.APIError,
             responseCode,
             "$urlPath - ${response?.toString()}"
         )

--- a/libsource/src/main/java/com/virtusize/libsource/network/VirtusizeApiTask.kt
+++ b/libsource/src/main/java/com/virtusize/libsource/network/VirtusizeApiTask.kt
@@ -218,7 +218,7 @@ internal class VirtusizeApiTask(
         var result: Any? = null
         if (errorStreamString != null) {
             result = try {
-                parseStringToObject(streamString = errorStreamString)
+                parseStringToObject(streamString = errorStreamString) ?: errorStreamString
             } catch (e: JSONException) {
                 errorStreamString
             }

--- a/libsource/src/main/java/com/virtusize/libsource/ui/VirtusizeInPageStandard.kt
+++ b/libsource/src/main/java/com/virtusize/libsource/ui/VirtusizeInPageStandard.kt
@@ -501,7 +501,7 @@ class VirtusizeInPageStandard(context: Context, attrs: AttributeSet) : Virtusize
             } catch (e: Exception) {
                 virtusizeMessageHandler.onError(
                     VirtusizeErrorType.PrivacyLinkNotOpen.virtusizeError(
-                        e.localizedMessage
+                        extraMessage = e.localizedMessage
                     )
                 )
             }

--- a/libsource/src/test/java/com/virtusize/libsource/network/VirtusizeAPIServiceTest.kt
+++ b/libsource/src/test/java/com/virtusize/libsource/network/VirtusizeAPIServiceTest.kt
@@ -296,7 +296,7 @@ class VirtusizeAPIServiceTest {
         ))
 
         val actualSuccessfulResponse = virtusizeAPIService.deleteUser().successData
-        assertThat(actualSuccessfulResponse).isEqualTo(expectedDeleteUserJsonResponse)
+        assertThat(actualSuccessfulResponse).isNull()
     }
 
     @Test
@@ -413,7 +413,7 @@ class VirtusizeAPIServiceTest {
         ))
 
         val actualError = virtusizeAPIService.getUserBodyProfile().failureData
-
+        println(actualError.toString())
         assertThat(actualError?.code).isEqualTo(HttpURLConnection.HTTP_NOT_FOUND)
         assertThat(actualError?.message).contains("{\"detail\":\"No wardrobe found\"}")
         assertThat(actualError?.type).isEqualTo(VirtusizeErrorType.APIError)

--- a/libsource/src/test/java/com/virtusize/libsource/network/VirtusizeAPIServiceTest.kt
+++ b/libsource/src/test/java/com/virtusize/libsource/network/VirtusizeAPIServiceTest.kt
@@ -413,7 +413,6 @@ class VirtusizeAPIServiceTest {
         ))
 
         val actualError = virtusizeAPIService.getUserBodyProfile().failureData
-        println(actualError.toString())
         assertThat(actualError?.code).isEqualTo(HttpURLConnection.HTTP_NOT_FOUND)
         assertThat(actualError?.message).contains("{\"detail\":\"No wardrobe found\"}")
         assertThat(actualError?.type).isEqualTo(VirtusizeErrorType.APIError)

--- a/libsource/src/test/java/com/virtusize/libsource/network/VirtusizeAPIServiceTest.kt
+++ b/libsource/src/test/java/com/virtusize/libsource/network/VirtusizeAPIServiceTest.kt
@@ -125,7 +125,7 @@ class VirtusizeAPIServiceTest {
 
         assertThat(actualError?.code).isEqualTo(500)
         assertThat(actualError?.message).contains(INTERNAL_SERVER_ERROR_RESPONSE)
-        assertThat(actualError?.type).isEqualTo(VirtusizeErrorType.NetworkError)
+        assertThat(actualError?.type).isEqualTo(VirtusizeErrorType.APIError)
     }
 
     @Test
@@ -349,7 +349,7 @@ class VirtusizeAPIServiceTest {
 
         assertThat(actualError?.code).isEqualTo(HttpURLConnection.HTTP_NOT_FOUND)
         assertThat(actualError?.message).contains("{\"detail\":\"No wardrobe found\"}")
-        assertThat(actualError?.type).isEqualTo(VirtusizeErrorType.NetworkError)
+        assertThat(actualError?.type).isEqualTo(VirtusizeErrorType.APIError)
     }
 
     @Test
@@ -416,7 +416,7 @@ class VirtusizeAPIServiceTest {
 
         assertThat(actualError?.code).isEqualTo(HttpURLConnection.HTTP_NOT_FOUND)
         assertThat(actualError?.message).contains("{\"detail\":\"No wardrobe found\"}")
-        assertThat(actualError?.type).isEqualTo(VirtusizeErrorType.NetworkError)
+        assertThat(actualError?.type).isEqualTo(VirtusizeErrorType.APIError)
     }
 
     @Test
@@ -465,7 +465,7 @@ class VirtusizeAPIServiceTest {
 
         assertThat(actualError?.code).isEqualTo(HttpURLConnection.HTTP_BAD_REQUEST)
         assertThat(actualError?.message).contains("/stg/ds-functions/size-rec/get-size - {\"Code\": \"BadRequestError\", \"Message\": \"BadRequestError: \"}")
-        assertThat(actualError?.type).isEqualTo(VirtusizeErrorType.NetworkError)
+        assertThat(actualError?.type).isEqualTo(VirtusizeErrorType.APIError)
     }
 
     companion object {

--- a/libsource/src/test/java/com/virtusize/libsource/network/VirtusizeApiTaskTest.kt
+++ b/libsource/src/test/java/com/virtusize/libsource/network/VirtusizeApiTaskTest.kt
@@ -153,7 +153,7 @@ class VirtusizeApiTaskTest {
                 virtusizeApiTask,
                 "{\"detail\":\"No wardrobe found\"}"
             )
-            assertThat(returnValue).isNull()
+            assertThat(returnValue).isEqualTo("{\"detail\":\"No wardrobe found\"}")
         }
     }
 

--- a/libsource/src/test/java/com/virtusize/libsource/network/VirtusizeApiTaskTest.kt
+++ b/libsource/src/test/java/com/virtusize/libsource/network/VirtusizeApiTaskTest.kt
@@ -1,0 +1,253 @@
+package com.virtusize.libsource.network
+
+import android.content.Context
+import android.os.Build
+import androidx.test.core.app.ApplicationProvider
+import com.google.common.truth.Truth.assertThat
+import com.virtusize.libsource.SharedPreferencesHelper
+import com.virtusize.libsource.data.parsers.*
+import com.virtusize.libsource.data.remote.*
+import com.virtusize.libsource.fixtures.ProductFixtures
+import com.virtusize.libsource.fixtures.TestFixtures
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [Build.VERSION_CODES.P])
+class VirtusizeApiTaskTest {
+    private val context: Context = ApplicationProvider.getApplicationContext()
+    private lateinit var virtusizeApiTask: VirtusizeApiTask
+
+    @Before
+    fun setup() {
+        virtusizeApiTask = VirtusizeApiTask(
+            null,
+            SharedPreferencesHelper.getInstance(context),
+            null
+        )
+    }
+
+    @Test
+    fun testParseInputStreamStringToUserBodyProfile_return_expectedUserBodyProfile() {
+        virtusizeApiTask
+            .setJsonParser(UserBodyProfileJsonParser())
+
+        val parseInputStreamStringToObjectMethod = VirtusizeApiTask::class.java.declaredMethods
+            .find { it.name == "parseInputStreamStringToObject" }
+        parseInputStreamStringToObjectMethod?.let { method ->
+            method.isAccessible = true
+            val returnValue = method.invoke(
+                virtusizeApiTask,
+                "",
+                TestFixtures.USER_BODY_JSONObject.toString()
+            )
+            val actualUserBodyProfile = returnValue as? UserBodyProfile
+            assertThat(actualUserBodyProfile?.age).isEqualTo(32)
+            assertThat(actualUserBodyProfile?.gender).isEqualTo("female")
+            assertThat(actualUserBodyProfile?.height).isEqualTo(1630)
+            assertThat(actualUserBodyProfile?.weight).isEqualTo("50.00")
+            assertThat(actualUserBodyProfile?.bodyData).isEqualTo(
+                mutableSetOf(
+                    Measurement("hip", 830),
+                    Measurement("hip", 830),
+                    Measurement("bust", 755),
+                    Measurement("neck", 300),
+                    Measurement("rise", 215),
+                    Measurement("bicep", 220),
+                    Measurement("thigh", 480),
+                    Measurement("waist", 630),
+                    Measurement("inseam", 700),
+                    Measurement("sleeve", 720),
+                    Measurement("shoulder", 370),
+                    Measurement("hipWidth", 300),
+                    Measurement("bustWidth", 245),
+                    Measurement("hipHeight", 750),
+                    Measurement("headHeight", 215),
+                    Measurement("kneeHeight", 395),
+                    Measurement("waistWidth", 225),
+                    Measurement("waistHeight", 920),
+                    Measurement("armpitHeight", 1130),
+                    Measurement("sleeveLength", 520),
+                    Measurement("shoulderWidth", 340),
+                    Measurement("shoulderHeight", 1240)
+                )
+            )
+        }
+    }
+
+    @Test
+    fun testParseInputStreamStringToUserBodyProfile_return_null() {
+        virtusizeApiTask
+            .setJsonParser(UserBodyProfileJsonParser())
+
+        val parseInputStreamStringToObjectMethod = VirtusizeApiTask::class.java.declaredMethods
+            .find { it.name == "parseInputStreamStringToObject" }
+        parseInputStreamStringToObjectMethod?.let { method ->
+            method.isAccessible = true
+            val returnValue = method.invoke(
+                virtusizeApiTask,
+                "",
+                "{\"gender\":\"\",\"age\":null,\"height\":null,\"weight\":null,\"braSize\":null,\"concernAreas\":null,\"bodyData\":null}")
+            assertThat(returnValue).isNull()
+        }
+    }
+
+    @Test
+    fun testParseErrorStreamStringToProductCheck_return_expectedProductCheck() {
+        virtusizeApiTask
+            .setJsonParser(ProductCheckJsonParser())
+
+        val parseErrorStreamStringToObjectMethod = VirtusizeApiTask::class.java.declaredMethods
+            .find { it.name == "parseErrorStreamStringToObject" }
+        parseErrorStreamStringToObjectMethod?.let { method ->
+            method.isAccessible = true
+            val returnValue = method.invoke(
+                virtusizeApiTask,
+                """
+                    {
+                        "data": {
+                            "productDataId": null, 
+                            "userData": {}, 
+                            "storeId": 2, 
+                            "storeName": "virtusize", 
+                            "validProduct": false, 
+                            "fetchMetaData": false
+                        }, 
+                        "name": "backend-checked-product", 
+                        "productId": "123"
+                    }
+                """
+                    .trimIndent()
+            )
+            val expectedProductCheck = ProductCheck(
+                Data(
+                    validProduct = false,
+                    fetchMetaData = false,
+                    shouldSeePhTooltip = false,
+                    productDataId = 0,
+                    productTypeName = "",
+                    storeName = "virtusize",
+                    storeId = 2,
+                    productTypeId = 0
+                ),
+                productId = "123",
+                name = "backend-checked-product"
+            )
+            assertThat(returnValue).isEqualTo(expectedProductCheck)
+        }
+    }
+
+    @Test
+    fun testParseErrorStreamStringToUserProduct_return_null() {
+        virtusizeApiTask
+            .setJsonParser(UserProductJsonParser())
+
+        val parseErrorStreamStringToObjectMethod = VirtusizeApiTask::class.java.declaredMethods
+            .find { it.name == "parseErrorStreamStringToObject" }
+        parseErrorStreamStringToObjectMethod?.let { method ->
+            method.isAccessible = true
+            val returnValue = method.invoke(
+                virtusizeApiTask,
+                "{\"detail\":\"No wardrobe found\"}"
+            )
+            assertThat(returnValue).isNull()
+        }
+    }
+
+    @Test
+    fun testParseStringToObjectByProductTypeJsonParser_return_ListOfProductType() {
+        virtusizeApiTask
+            .setJsonParser(ProductTypeJsonParser())
+
+        val parseStringToObjectMethod = VirtusizeApiTask::class.java.declaredMethods
+            .find { it.name == "parseStringToObject" }
+        parseStringToObjectMethod?.let { method ->
+            method.isAccessible = true
+            val returnValue = method.invoke(
+                virtusizeApiTask,
+                "https://staging.virtusize.jp/a/api/v3/product-types",
+                ProductFixtures.PRODUCT_TYPE_JSON_ARRAY.toString()
+            )
+            val productTypes = returnValue as List<ProductType>
+            assertThat(productTypes.size).isEqualTo(4)
+        }
+    }
+
+    @Test
+    fun testParseStringToObjectByUserSessionInfoJsonParser_return_expectedUserSessionInfo() {
+        virtusizeApiTask
+            .setJsonParser(UserSessionInfoJsonParser())
+
+        val parseStringToObjectMethod = VirtusizeApiTask::class.java.declaredMethods
+            .find { it.name == "parseStringToObject" }
+
+        parseStringToObjectMethod?.let { method ->
+            method.isAccessible = true
+            val streamString = """
+                    {
+                        "id":"test_access_token",
+                        "expiresAt":1619062232,
+                        "user":{
+                            "id":null,
+                            "bid":"test_bid",
+                            "authType":"EMPTY",
+                            "created":null,
+                            "lastLogin":null,
+                            "firstName":"Anonymous",
+                            "language":null
+                        },
+                        "x-vs-auth":""
+                    }
+                """.trimIndent().replace("\\s+|[\\n]+".toRegex(), "")
+
+            val returnValue = method.invoke(
+                virtusizeApiTask,
+                "https://staging.virtusize.jp/a/api/v3/sessions",
+                streamString
+            )
+
+            val expectedUserSessionInfo = UserSessionInfo(
+                accessToken = "test_access_token",
+                bid = "test_bid",
+                authToken = "",
+                userSessionResponse = streamString
+            )
+            assertThat(returnValue).isEqualTo(expectedUserSessionInfo)
+        }
+    }
+
+
+
+    @Test
+    fun testParseStringToObjectByUserBodyProfileJsonParser_return_null() {
+        virtusizeApiTask
+            .setJsonParser(UserBodyProfileJsonParser())
+
+        val parseStringToObjectMethod = VirtusizeApiTask::class.java.declaredMethods
+            .find { it.name == "parseStringToObject" }
+
+        parseStringToObjectMethod?.let { method ->
+            method.isAccessible = true
+            val returnValue = method.invoke(
+                virtusizeApiTask,
+                "https://staging.virtusize.jp/a/api/v3/user-body-measurements",
+                """
+                    {
+                        "gender":"",
+                        "age":null,
+                        "height":null,
+                        "weight":null,
+                        "braSize":null,
+                        "concernAreas":null,
+                        "bodyData":null
+                    }
+                """.trimIndent()
+            )
+
+            assertThat(returnValue).isNull()
+        }
+    }
+}


### PR DESCRIPTION
## Summary
<img width="853" alt="Screen Shot 2021-04-19 at 17 13 41" src="https://user-images.githubusercontent.com/7802052/115203643-9da1de80-a132-11eb-9008-dc924e9cccd0.png">

The crash was caused by the `parseInputStreamAsObject` function in VirtusizeApiTask.kt returning a JSON string instead of returning null for **UserBodyProfile**. The `getBodyProfileRecommendedSize` function in VirtusizeRepository.kt required the type of userBodyProfile to be exactly **UserBodyProfile** but userBodyProfileResponse.successData that was passed into this function was a JSON string from `parseInputStreamAsObject`. Hence, an Exception was thrown.

- [x] Fix the crash when a user's body profile is null
- [x] Refactor the code where it parses the input stream and error stream from the HttpsURLConnection