### PR TITLE
Feature: Enable SNS buttons for the Webview

### DIFF
--- a/libsource/src/main/java/com/virtusize/libsource/ui/VirtusizeWebViewFragment.kt
+++ b/libsource/src/main/java/com/virtusize/libsource/ui/VirtusizeWebViewFragment.kt
@@ -63,6 +63,7 @@ class VirtusizeWebViewFragment: DialogFragment() {
             override fun onPageFinished(view: WebView?, url: String?) {
                 if(url != null && url.contains(virtusizeWebAppUrl)) {
                     webView?.evaluateJavascript(vsParamsFromSDKScript, null)
+                    webView?.evaluateJavascript("javascript:window.virtusizeSNSEnabled = true;", null)
                     getBrowserIDFromCookies()?.let { bid ->
                         if(bid != sharedPreferencesHelper.getBrowserId()) {
                             sharedPreferencesHelper.storeBrowserId(bid)

--- a/sampleAppKotlin/build.gradle
+++ b/sampleAppKotlin/build.gradle
@@ -34,6 +34,6 @@ dependencies {
     implementation "androidx.appcompat:appcompat:$appcompat_version"
     implementation "androidx.constraintlayout:constraintlayout:$constraint_layout_version"
 
-    implementation 'com.github.virtusize:integration_android:2.2'
-//    implementation project(":libsource")
+//    implementation 'com.github.virtusize:integration_android:2.2'
+    implementation project(":libsource")
 }

--- a/sampleAppKotlin/src/main/java/com/virtusize/android/MainActivity.kt
+++ b/sampleAppKotlin/src/main/java/com/virtusize/android/MainActivity.kt
@@ -95,7 +95,7 @@ class MainActivity : AppCompatActivity() {
                 fragmentTransaction.remove(fragment)
             }
             fragmentTransaction.addToBackStack(null)
-            SampleWebViewFragment().show(fragmentTransaction, Constants.FRAG_TAG)
+            WebViewFragment().show(fragmentTransaction, Constants.FRAG_TAG)
         }
 
         /*

--- a/sampleAppKotlin/src/main/java/com/virtusize/android/MainActivity.kt
+++ b/sampleAppKotlin/src/main/java/com/virtusize/android/MainActivity.kt
@@ -4,7 +4,6 @@ import android.os.Bundle
 import android.util.Log
 import androidx.appcompat.app.AppCompatActivity
 import com.virtusize.libsource.data.local.*
-import com.virtusize.libsource.data.local.VirtusizeOrder
 import com.virtusize.libsource.util.Constants
 import com.virtusize.libsource.util.dpInPx
 import com.virtusize.libsource.util.spToPx

--- a/sampleAppKotlin/src/main/java/com/virtusize/android/SampleWebViewFragment.kt
+++ b/sampleAppKotlin/src/main/java/com/virtusize/android/SampleWebViewFragment.kt
@@ -39,14 +39,12 @@ class SampleWebViewFragment: DialogFragment() {
 
         webView = view.findViewById(R.id.webView)
         webView.webViewClient = object : WebViewClient() {
-            override fun shouldOverrideUrlLoading(
-                view: WebView?,
-                request: WebResourceRequest?
-            ): Boolean {
-                Log.d(TAG, "shouldOverrideUrlLoading ${view?.url}")
-                return super.shouldOverrideUrlLoading(view, request)
+            override fun onPageFinished(view: WebView?, url: String?) {
+                Log.d(TAG, "onPageFinished ${view?.url}")
+                super.onPageFinished(view, url)
             }
         }
+
         webView.webChromeClient = object : WebChromeClient() {
             override fun onCreateWindow(
                 view: WebView?,

--- a/sampleAppKotlin/src/main/java/com/virtusize/android/WebViewFragment.kt
+++ b/sampleAppKotlin/src/main/java/com/virtusize/android/WebViewFragment.kt
@@ -8,10 +8,10 @@ import android.webkit.*
 import androidx.fragment.app.DialogFragment
 import com.virtusize.libsource.VirtusizeWebView
 
-class SampleWebViewFragment: DialogFragment() {
+class WebViewFragment: DialogFragment() {
 
     companion object {
-        private val TAG = SampleWebViewFragment::class.simpleName
+        private val TAG = WebViewFragment::class.simpleName
     }
 
     private lateinit var webView: VirtusizeWebView
@@ -39,6 +39,10 @@ class SampleWebViewFragment: DialogFragment() {
 
         webView = view.findViewById(R.id.webView)
         webView.webViewClient = object : WebViewClient() {
+            override fun shouldOverrideUrlLoading(view: WebView?, url: String): Boolean {
+                Log.d(TAG, "shouldOverrideUrlLoading ${view?.url}")
+                return false
+            }
             override fun onPageFinished(view: WebView?, url: String?) {
                 Log.d(TAG, "onPageFinished ${view?.url}")
                 super.onPageFinished(view, url)
@@ -52,7 +56,7 @@ class SampleWebViewFragment: DialogFragment() {
                 isUserGesture: Boolean,
                 resultMsg: Message?
             ): Boolean {
-                Log.d(TAG, "onCreateWindow")
+                Log.d(TAG, "onCreateWindow ${view?.url}")
                 return super.onCreateWindow(view, isDialog, isUserGesture, resultMsg)
             }
 


### PR DESCRIPTION
## Summary
The SNS buttons are hidden by default when Aoyama is loaded in a web view.
To enable these buttons, the webview executes `window.virtusizeSNSEnabled = true;` when the webpage has finished loading.

**Before**
<img width="279" alt="Screen Shot 2021-07-09 at 11 14 42" src="https://user-images.githubusercontent.com/7802052/125013490-e10f4780-e0a6-11eb-8327-a88aa40a119c.png">

**After**
<img width="282" alt="Screen Shot 2021-07-09 at 11 13 18" src="https://user-images.githubusercontent.com/7802052/125013377-b1f8d600-e0a6-11eb-8a3e-f49ce3680e85.png">
