### PR TITLE
[NSDK-184] Hotfix - Update README.md and Gradle Build Files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 2.5.5
+
+* Updated Size Recommendation API related URL, request model, response model.
+* Added environment related size recommendation base URLs.
+* Updated unit test
+
 ## 2.5.1
 
 * Handle SNS auth for web view apps

--- a/README-JP.md
+++ b/README-JP.md
@@ -58,7 +58,7 @@ You need a unique API key and an Admin account, only available to Virtusize cust
 ## 対応バージョン
 
 - minSdkVersion >= 21
-- compileSdkVersion >= 30
+- compileSdkVersion >= 34
 - Setup in AppCompatActivity
 
 

--- a/README-JP.md
+++ b/README-JP.md
@@ -74,7 +74,7 @@ In your appの`build.gradle`ファイルに下記のdependencyを追加
 
 ```groovy
 dependencies {
-  implementation 'com.virtusize.android:virtusize:2.5.1'
+  implementation 'com.virtusize.android:virtusize:2.5.5'
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ You need a unique API key and an Admin account, only available to Virtusize cust
 ## Requirements
 
 - minSdkVersion >= 21
-- compileSdkVersion >= 30
+- compileSdkVersion >= 34
 - Setup in AppCompatActivity
 
 

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ In your app `build.gradle` file, add the following dependencies:
 
 ```groovy
 dependencies {
-  implementation 'com.virtusize.android:virtusize:2.5.1'
+  implementation 'com.virtusize.android:virtusize:2.5.5'
 }
 ```
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 buildscript {
     ext {
-        gradle_version = '8.1.0'
+        gradle_version = '8.5.0'
         kotlin_version = '1.8.22'
     }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -14,4 +14,3 @@ android.enableJetifier=true
 android.useAndroidX=true
 android.defaults.buildfeatures.buildconfig=true
 android.nonTransitiveRClass=false
-android.nonFinalResIds=false

--- a/gradle.properties
+++ b/gradle.properties
@@ -13,4 +13,3 @@ kotlin.code.style=official
 android.enableJetifier=true
 android.useAndroidX=true
 android.defaults.buildfeatures.buildconfig=true
-android.nonTransitiveRClass=false

--- a/gradle/deploy.gradle
+++ b/gradle/deploy.gradle
@@ -18,13 +18,15 @@ afterEvaluate {
         publications {
             // Creates a Maven publication called "release".
             release(MavenPublication) {
-                // Applies the component for the release build variant.
-                from components.release
-
                 // You can then customize attributes of the publication as shown below.
                 groupId = rootProject.group
                 artifactId = project.artifactId
                 version = rootProject.version
+
+                // Applies the component for the release build variant.
+                afterEvaluate {
+                    from components.release
+                }
 
                 pom {
                     name = project.artifactName

--- a/gradle/deploy.gradle
+++ b/gradle/deploy.gradle
@@ -1,26 +1,15 @@
 apply plugin: 'maven-publish'
 apply plugin: 'signing'
 
-task androidSourcesJar(type: Jar) {
-    //archiveClassifier.set('sources')
-    from android.sourceSets.main.java.srcDirs
+android {
+    publishing {
+        singleVariant("release") {
+            withSourcesJar()
+            // TODO: Fix error. See: https://github.com/Kotlin/dokka/issues/2956
+            // withJavadocJar()
+        }
+    }
 }
-
-//task androidJavadocs(type: Javadoc) {
-//    source = android.sourceSets.main.java.srcDirs
-//    excludes = ['**/*.kt'] // Exclude all kotlin files from javadoc file.
-//    classpath += project.files(android.getBootClasspath().join(File.pathSeparator))
-//}
-//
-//task androidJavadocsJar(type: Jar, dependsOn: androidJavadocs) {
-//    archiveClassifier.set('javadoc')
-//    from androidJavadocs.destinationDir
-//}
-//
-//artifacts {
-//    archives androidSourcesJar
-//    archives androidJavadocsJar
-//}
 
 // Because the components are created only during the afterEvaluate phase, you must
 // configure your publications using the afterEvaluate() lifecycle method.
@@ -31,10 +20,6 @@ afterEvaluate {
             release(MavenPublication) {
                 // Applies the component for the release build variant.
                 from components.release
-
-                // Adds Javadocs and Sources as separate jars.
-                artifact androidSourcesJar
-                //artifact androidJavadocsJar
 
                 // You can then customize attributes of the publication as shown below.
                 groupId = rootProject.group

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Fri Sep 15 13:09:48 IST 2023
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/sampleAppKotlin/src/main/java/com/virtusize/sampleappkotlin/WebViewFragment.kt
+++ b/sampleAppKotlin/src/main/java/com/virtusize/sampleappkotlin/WebViewFragment.kt
@@ -33,12 +33,12 @@ class WebViewFragment: DialogFragment() {
 
     override fun onActivityCreated(savedInstanceState: Bundle?) {
         super.onActivityCreated(savedInstanceState)
-        dialog?.window?.attributes?.windowAnimations = R.style.VirtusizeDialogFragmentAnimation
+        dialog?.window?.attributes?.windowAnimations = com.virtusize.android.R.style.VirtusizeDialogFragmentAnimation
     }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        setStyle(STYLE_NORMAL, R.style.FullScreenDialogStyle)
+        setStyle(STYLE_NORMAL, com.virtusize.android.R.style.FullScreenDialogStyle)
     }
 
     override fun onCreateView(

--- a/virtusize-core/build.gradle
+++ b/virtusize-core/build.gradle
@@ -5,11 +5,11 @@ plugins {
 }
 
 android {
-    compileSdk 34
+    compileSdk rootProject.ext.compileSdkVersion
 
     defaultConfig {
-        minSdk 21
-        targetSdk 34
+        minSdkVersion rootProject.ext.minSdkVersion
+        targetSdkVersion rootProject.ext.targetSdkVersion
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles "consumer-rules.pro"

--- a/virtusize-core/build.gradle
+++ b/virtusize-core/build.gradle
@@ -68,7 +68,3 @@ ext {
 
 apply from: "${rootDir}/gradle/ktlint.gradle"
 apply from: "${rootDir}/gradle/deploy.gradle"
-
-afterEvaluate {
-    generateMetadataFileForReleasePublication.dependsOn androidSourcesJar
-}

--- a/virtusize-core/build.gradle
+++ b/virtusize-core/build.gradle
@@ -49,7 +49,7 @@ dependencies {
     implementation 'androidx.core:core-ktx:1.12.0'
     implementation 'androidx.appcompat:appcompat:1.6.1'
     implementation 'com.google.android.material:material:1.9.0'
-    implementation 'com.squareup.retrofit2:converter-gson:2.9.0'
+
     testImplementation 'androidx.test:core:1.5.0'
     testImplementation "com.google.truth:truth:1.1.2"
     testImplementation 'junit:junit:4.+'

--- a/virtusize-core/src/main/java/com/virtusize/android/data/local/BodyProfileRecommendedSizeParams.kt
+++ b/virtusize-core/src/main/java/com/virtusize/android/data/local/BodyProfileRecommendedSizeParams.kt
@@ -75,8 +75,6 @@ internal data class BodyProfileRecommendedSizeParams constructor(
                 measurement.name to measurement.millimeter
             }
         }
-        /*val gender = storeProduct.storeProductMeta?.additionalInfo?.gender
-            ?: storeProduct.storeProductMeta?.gender*/
         return emptyMap<String, Any?>()
             .plus(
                 mapOf(PARAM_BRAND to (brand ?: ""))
@@ -99,12 +97,6 @@ internal data class BodyProfileRecommendedSizeParams constructor(
                 mapOf(PARAM_GENDER to userBodyProfile.gender)
             )
     }
-
-    /*private fun createModelInfoParams(): Map<String, Any?> {
-        return emptyMap<String, Any?>()
-            .plus("height" to userBodyProfile.height)
-            .plus("size" to "small")
-    }*/
 
     /**
      * Creates the map that represents the user body data

--- a/virtusize/build.gradle
+++ b/virtusize/build.gradle
@@ -11,6 +11,9 @@ android {
     defaultConfig {
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
+        aarMetadata {
+            minCompileSdk = rootProject.ext.minSdkVersion
+        }
     }
 
     buildTypes {
@@ -55,7 +58,6 @@ dependencies {
     implementation 'androidx.browser:browser:1.6.0'
     implementation "androidx.cardview:cardview:1.0.0"
     implementation "androidx.lifecycle:lifecycle-viewmodel-ktx:$lifecycle_version"
-    implementation 'com.squareup.retrofit2:converter-gson:2.9.0'
 
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:$coroutine_version"

--- a/virtusize/build.gradle
+++ b/virtusize/build.gradle
@@ -77,7 +77,3 @@ ext {
 
 apply from: "${rootDir}/gradle/ktlint.gradle"
 apply from: "${rootDir}/gradle/deploy.gradle"
-
-afterEvaluate {
-    generateMetadataFileForReleasePublication.dependsOn androidSourcesJar
-}

--- a/virtusize/build.gradle
+++ b/virtusize/build.gradle
@@ -5,15 +5,11 @@ plugins {
 }
 
 android {
-
     compileSdk rootProject.ext.compileSdkVersion
 
     defaultConfig {
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        aarMetadata {
-            minCompileSdk = rootProject.ext.minSdkVersion
-        }
     }
 
     buildTypes {

--- a/virtusize/src/main/java/com/virtusize/android/data/parsers/I18nLocalizationJsonParser.kt
+++ b/virtusize/src/main/java/com/virtusize/android/data/parsers/I18nLocalizationJsonParser.kt
@@ -27,67 +27,93 @@ internal class I18nLocalizationJsonParser(
         val configuredContext = VirtusizeUtils.getConfiguredContext(context, virtusizeLanguage)
         val defaultAccessoryText = inpageJSONObject?.optString(
             FIELD_DEFAULT_ACCESSORY_TEXT,
-            configuredContext?.getString(com.virtusize.android.core.R.string.inpage_default_accessory_text) ?: ""
+            configuredContext?.getString(
+                com.virtusize.android.core.R.string.inpage_default_accessory_text
+            ) ?: ""
         ) ?: ""
 
         val hasProductAccessoryTopText = accessoryJSONObject?.optString(
             FIELD_HAS_PRODUCT_LEAD,
-            configuredContext?.getString(com.virtusize.android.core.R.string.inpage_has_product_top_text) ?: ""
+            configuredContext?.getString(
+                com.virtusize.android.core.R.string.inpage_has_product_top_text
+            ) ?: ""
         ) ?: ""
 
         val hasProductAccessoryBottomText = accessoryJSONObject?.optString(
             FIELD_HAS_PRODUCT,
-            configuredContext?.getString(com.virtusize.android.core.R.string.inpage_has_product_bottom_text) ?: ""
+            configuredContext?.getString(
+                com.virtusize.android.core.R.string.inpage_has_product_bottom_text
+            ) ?: ""
         ) ?: ""
 
         val oneSizeCloseTopText = oneSizeJSONObject?.optString(
             FIELD_CLOSE_LEAD,
-            configuredContext?.getString(com.virtusize.android.core.R.string.inpage_one_size_close_top_text) ?: ""
+            configuredContext?.getString(
+                com.virtusize.android.core.R.string.inpage_one_size_close_top_text
+            ) ?: ""
         ) ?: ""
 
         val oneSizeSmallerTopText = oneSizeJSONObject?.optString(
             FIELD_SMALLER_LEAD,
-            configuredContext?.getString(com.virtusize.android.core.R.string.inpage_one_size_smaller_top_text) ?: ""
+            configuredContext?.getString(
+                com.virtusize.android.core.R.string.inpage_one_size_smaller_top_text
+            ) ?: ""
         ) ?: ""
 
         val oneSizeLargerTopText = oneSizeJSONObject?.optString(
             FIELD_LARGER_LEAD,
-            configuredContext?.getString(com.virtusize.android.core.R.string.inpage_one_size_larger_top_text) ?: ""
+            configuredContext?.getString(
+                com.virtusize.android.core.R.string.inpage_one_size_larger_top_text
+            ) ?: ""
         ) ?: ""
 
         val oneSizeCloseBottomText = oneSizeJSONObject?.optString(
             FIELD_CLOSE,
-            configuredContext?.getString(com.virtusize.android.core.R.string.inpage_one_size_close_bottom_text) ?: ""
+            configuredContext?.getString(
+                com.virtusize.android.core.R.string.inpage_one_size_close_bottom_text
+            ) ?: ""
         ) ?: ""
 
         val oneSizeSmallerBottomText = oneSizeJSONObject?.optString(
             FIELD_SMALLER,
-            configuredContext?.getString(com.virtusize.android.core.R.string.inpage_one_size_smaller_bottom_text) ?: ""
+            configuredContext?.getString(
+                com.virtusize.android.core.R.string.inpage_one_size_smaller_bottom_text
+            ) ?: ""
         ) ?: ""
 
         val oneSizeLargerBottomText = oneSizeJSONObject?.optString(
             FIELD_LARGER,
-            configuredContext?.getString(com.virtusize.android.core.R.string.inpage_one_size_larger_bottom_text) ?: ""
+            configuredContext?.getString(
+                com.virtusize.android.core.R.string.inpage_one_size_larger_bottom_text
+            ) ?: ""
         ) ?: ""
 
         val bodyProfileOneSizeText = oneSizeJSONObject?.optString(
             FIELD_BODY_PROFILE,
-            configuredContext?.getString(com.virtusize.android.core.R.string.inpage_one_size_body_profile_text) ?: ""
+            configuredContext?.getString(
+                com.virtusize.android.core.R.string.inpage_one_size_body_profile_text
+            ) ?: ""
         ) ?: ""
 
         val sizeComparisonMultiSizeText = multiSizeJSONObject?.optString(
             FIELD_SIZE_COMPARISON,
-            configuredContext?.getString(com.virtusize.android.core.R.string.inpage_multi_size_comparison_text) ?: ""
+            configuredContext?.getString(
+                com.virtusize.android.core.R.string.inpage_multi_size_comparison_text
+            ) ?: ""
         ) ?: ""
 
         val bodyProfileMultiSizeText = multiSizeJSONObject?.optString(
             FIELD_BODY_PROFILE,
-            configuredContext?.getString(com.virtusize.android.core.R.string.inpage_multi_size_body_profile_text) ?: ""
+            configuredContext?.getString(
+                com.virtusize.android.core.R.string.inpage_multi_size_body_profile_text
+            ) ?: ""
         ) ?: ""
 
         val defaultNoDataText = inpageJSONObject?.optString(
             FIELD_NO_DATA_TEXT,
-            configuredContext?.getString(com.virtusize.android.core.R.string.inpage_no_data_text) ?: ""
+            configuredContext?.getString(
+                com.virtusize.android.core.R.string.inpage_no_data_text
+            ) ?: ""
         ) ?: ""
 
         return I18nLocalization(

--- a/virtusize/src/main/java/com/virtusize/android/data/parsers/I18nLocalizationJsonParser.kt
+++ b/virtusize/src/main/java/com/virtusize/android/data/parsers/I18nLocalizationJsonParser.kt
@@ -15,7 +15,7 @@ internal class I18nLocalizationJsonParser(
     private val virtusizeLanguage: VirtusizeLanguage?
 ) : VirtusizeJsonParser<I18nLocalization> {
 
-    override fun parse(json: JSONObject): I18nLocalization? {
+    override fun parse(json: JSONObject): I18nLocalization {
         val aoyamaJSONObject = json.optJSONObject(FIELD_KEYS)
             ?.optJSONObject(FIELD_APPS)
             ?.optJSONObject(FIELD_AOYAMA)
@@ -27,67 +27,67 @@ internal class I18nLocalizationJsonParser(
         val configuredContext = VirtusizeUtils.getConfiguredContext(context, virtusizeLanguage)
         val defaultAccessoryText = inpageJSONObject?.optString(
             FIELD_DEFAULT_ACCESSORY_TEXT,
-            configuredContext?.getString(R.string.inpage_default_accessory_text) ?: ""
+            configuredContext?.getString(com.virtusize.android.core.R.string.inpage_default_accessory_text) ?: ""
         ) ?: ""
 
         val hasProductAccessoryTopText = accessoryJSONObject?.optString(
             FIELD_HAS_PRODUCT_LEAD,
-            configuredContext?.getString(R.string.inpage_has_product_top_text) ?: ""
+            configuredContext?.getString(com.virtusize.android.core.R.string.inpage_has_product_top_text) ?: ""
         ) ?: ""
 
         val hasProductAccessoryBottomText = accessoryJSONObject?.optString(
             FIELD_HAS_PRODUCT,
-            configuredContext?.getString(R.string.inpage_has_product_bottom_text) ?: ""
+            configuredContext?.getString(com.virtusize.android.core.R.string.inpage_has_product_bottom_text) ?: ""
         ) ?: ""
 
         val oneSizeCloseTopText = oneSizeJSONObject?.optString(
             FIELD_CLOSE_LEAD,
-            configuredContext?.getString(R.string.inpage_one_size_close_top_text) ?: ""
+            configuredContext?.getString(com.virtusize.android.core.R.string.inpage_one_size_close_top_text) ?: ""
         ) ?: ""
 
         val oneSizeSmallerTopText = oneSizeJSONObject?.optString(
             FIELD_SMALLER_LEAD,
-            configuredContext?.getString(R.string.inpage_one_size_smaller_top_text) ?: ""
+            configuredContext?.getString(com.virtusize.android.core.R.string.inpage_one_size_smaller_top_text) ?: ""
         ) ?: ""
 
         val oneSizeLargerTopText = oneSizeJSONObject?.optString(
             FIELD_LARGER_LEAD,
-            configuredContext?.getString(R.string.inpage_one_size_larger_top_text) ?: ""
+            configuredContext?.getString(com.virtusize.android.core.R.string.inpage_one_size_larger_top_text) ?: ""
         ) ?: ""
 
         val oneSizeCloseBottomText = oneSizeJSONObject?.optString(
             FIELD_CLOSE,
-            configuredContext?.getString(R.string.inpage_one_size_close_bottom_text) ?: ""
+            configuredContext?.getString(com.virtusize.android.core.R.string.inpage_one_size_close_bottom_text) ?: ""
         ) ?: ""
 
         val oneSizeSmallerBottomText = oneSizeJSONObject?.optString(
             FIELD_SMALLER,
-            configuredContext?.getString(R.string.inpage_one_size_smaller_bottom_text) ?: ""
+            configuredContext?.getString(com.virtusize.android.core.R.string.inpage_one_size_smaller_bottom_text) ?: ""
         ) ?: ""
 
         val oneSizeLargerBottomText = oneSizeJSONObject?.optString(
             FIELD_LARGER,
-            configuredContext?.getString(R.string.inpage_one_size_larger_bottom_text) ?: ""
+            configuredContext?.getString(com.virtusize.android.core.R.string.inpage_one_size_larger_bottom_text) ?: ""
         ) ?: ""
 
         val bodyProfileOneSizeText = oneSizeJSONObject?.optString(
             FIELD_BODY_PROFILE,
-            configuredContext?.getString(R.string.inpage_one_size_body_profile_text) ?: ""
+            configuredContext?.getString(com.virtusize.android.core.R.string.inpage_one_size_body_profile_text) ?: ""
         ) ?: ""
 
         val sizeComparisonMultiSizeText = multiSizeJSONObject?.optString(
             FIELD_SIZE_COMPARISON,
-            configuredContext?.getString(R.string.inpage_multi_size_comparison_text) ?: ""
+            configuredContext?.getString(com.virtusize.android.core.R.string.inpage_multi_size_comparison_text) ?: ""
         ) ?: ""
 
         val bodyProfileMultiSizeText = multiSizeJSONObject?.optString(
             FIELD_BODY_PROFILE,
-            configuredContext?.getString(R.string.inpage_multi_size_body_profile_text) ?: ""
+            configuredContext?.getString(com.virtusize.android.core.R.string.inpage_multi_size_body_profile_text) ?: ""
         ) ?: ""
 
         val defaultNoDataText = inpageJSONObject?.optString(
             FIELD_NO_DATA_TEXT,
-            configuredContext?.getString(R.string.inpage_no_data_text) ?: ""
+            configuredContext?.getString(com.virtusize.android.core.R.string.inpage_no_data_text) ?: ""
         ) ?: ""
 
         return I18nLocalization(

--- a/virtusize/src/test/java/com/virtusize/android/data/parsers/I18nLocalizationJsonParserTest.kt
+++ b/virtusize/src/test/java/com/virtusize/android/data/parsers/I18nLocalizationJsonParserTest.kt
@@ -94,19 +94,19 @@ class I18nLocalizationJsonParserTest {
 
     private fun getExpectedI18nLocalization(localizedContext: Context): I18nLocalization {
         return I18nLocalization(
-            localizedContext.getString(R.string.inpage_default_accessory_text),
-            localizedContext.getString(R.string.inpage_has_product_top_text),
-            localizedContext.getString(R.string.inpage_has_product_bottom_text),
-            localizedContext.getString(R.string.inpage_one_size_close_top_text),
-            localizedContext.getString(R.string.inpage_one_size_smaller_top_text),
-            localizedContext.getString(R.string.inpage_one_size_larger_top_text),
-            localizedContext.getString(R.string.inpage_one_size_close_bottom_text),
-            localizedContext.getString(R.string.inpage_one_size_smaller_bottom_text),
-            localizedContext.getString(R.string.inpage_one_size_larger_bottom_text),
-            localizedContext.getString(R.string.inpage_one_size_body_profile_text),
-            localizedContext.getString(R.string.inpage_multi_size_comparison_text),
-            localizedContext.getString(R.string.inpage_multi_size_body_profile_text),
-            localizedContext.getString(R.string.inpage_no_data_text)
+            localizedContext.getString(com.virtusize.android.core.R.string.inpage_default_accessory_text),
+            localizedContext.getString(com.virtusize.android.core.R.string.inpage_has_product_top_text),
+            localizedContext.getString(com.virtusize.android.core.R.string.inpage_has_product_bottom_text),
+            localizedContext.getString(com.virtusize.android.core.R.string.inpage_one_size_close_top_text),
+            localizedContext.getString(com.virtusize.android.core.R.string.inpage_one_size_smaller_top_text),
+            localizedContext.getString(com.virtusize.android.core.R.string.inpage_one_size_larger_top_text),
+            localizedContext.getString(com.virtusize.android.core.R.string.inpage_one_size_close_bottom_text),
+            localizedContext.getString(com.virtusize.android.core.R.string.inpage_one_size_smaller_bottom_text),
+            localizedContext.getString(com.virtusize.android.core.R.string.inpage_one_size_larger_bottom_text),
+            localizedContext.getString(com.virtusize.android.core.R.string.inpage_one_size_body_profile_text),
+            localizedContext.getString(com.virtusize.android.core.R.string.inpage_multi_size_comparison_text),
+            localizedContext.getString(com.virtusize.android.core.R.string.inpage_multi_size_body_profile_text),
+            localizedContext.getString(com.virtusize.android.core.R.string.inpage_no_data_text)
         )
     }
 }

--- a/virtusize/src/test/java/com/virtusize/android/data/parsers/I18nLocalizationJsonParserTest.kt
+++ b/virtusize/src/test/java/com/virtusize/android/data/parsers/I18nLocalizationJsonParserTest.kt
@@ -94,19 +94,45 @@ class I18nLocalizationJsonParserTest {
 
     private fun getExpectedI18nLocalization(localizedContext: Context): I18nLocalization {
         return I18nLocalization(
-            localizedContext.getString(com.virtusize.android.core.R.string.inpage_default_accessory_text),
-            localizedContext.getString(com.virtusize.android.core.R.string.inpage_has_product_top_text),
-            localizedContext.getString(com.virtusize.android.core.R.string.inpage_has_product_bottom_text),
-            localizedContext.getString(com.virtusize.android.core.R.string.inpage_one_size_close_top_text),
-            localizedContext.getString(com.virtusize.android.core.R.string.inpage_one_size_smaller_top_text),
-            localizedContext.getString(com.virtusize.android.core.R.string.inpage_one_size_larger_top_text),
-            localizedContext.getString(com.virtusize.android.core.R.string.inpage_one_size_close_bottom_text),
-            localizedContext.getString(com.virtusize.android.core.R.string.inpage_one_size_smaller_bottom_text),
-            localizedContext.getString(com.virtusize.android.core.R.string.inpage_one_size_larger_bottom_text),
-            localizedContext.getString(com.virtusize.android.core.R.string.inpage_one_size_body_profile_text),
-            localizedContext.getString(com.virtusize.android.core.R.string.inpage_multi_size_comparison_text),
-            localizedContext.getString(com.virtusize.android.core.R.string.inpage_multi_size_body_profile_text),
-            localizedContext.getString(com.virtusize.android.core.R.string.inpage_no_data_text)
+            localizedContext.getString(
+                com.virtusize.android.core.R.string.inpage_default_accessory_text
+            ),
+            localizedContext.getString(
+                com.virtusize.android.core.R.string.inpage_has_product_top_text
+            ),
+            localizedContext.getString(
+                com.virtusize.android.core.R.string.inpage_has_product_bottom_text
+            ),
+            localizedContext.getString(
+                com.virtusize.android.core.R.string.inpage_one_size_close_top_text
+            ),
+            localizedContext.getString(
+                com.virtusize.android.core.R.string.inpage_one_size_smaller_top_text
+            ),
+            localizedContext.getString(
+                com.virtusize.android.core.R.string.inpage_one_size_larger_top_text
+            ),
+            localizedContext.getString(
+                com.virtusize.android.core.R.string.inpage_one_size_close_bottom_text
+            ),
+            localizedContext.getString(
+                com.virtusize.android.core.R.string.inpage_one_size_smaller_bottom_text
+            ),
+            localizedContext.getString(
+                com.virtusize.android.core.R.string.inpage_one_size_larger_bottom_text
+            ),
+            localizedContext.getString(
+                com.virtusize.android.core.R.string.inpage_one_size_body_profile_text
+            ),
+            localizedContext.getString(
+                com.virtusize.android.core.R.string.inpage_multi_size_comparison_text
+            ),
+            localizedContext.getString(
+                com.virtusize.android.core.R.string.inpage_multi_size_body_profile_text
+            ),
+            localizedContext.getString(
+                com.virtusize.android.core.R.string.inpage_no_data_text
+            )
         )
     }
 }


### PR DESCRIPTION
### Description

- Updated README.md and README-JP.md
- Updated Android Gradle plugin version to 8.5 and Gradle version to 8.7
https://developer.android.com/build/releases/gradle-plugin#updating-gradle
- Updated publishing gradle setup. Above Gradle 7.1, there's new publishing API https://developer.android.com/build/releases/past-releases/agp-7-1-0-release-notes#build-variant-publishing
https://developer.android.com/build/publish-library/configure-pub-variants
- Removed unused commented code
- Removed android.nonTransitiveRClass=false and android.nonFinalResIds=false in gradle.properties
There were some breaking changes in AGP 8.0, but it's not necessary to set them back to the old default values after fixing the R resource paths
https://developer.android.com/build/releases/past-releases/agp-8-0-0-release-notes#default-changes

### Demo

None

### Ticket

https://app.clickup.com/t/3702259/NSDK-184