### PR TITLE
[NSDK-193] Jetpack Compose AndroidView For VirtusizeButton

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,15 +1,24 @@
-### Description
+## 🔗 Related Links
 
-_Describe why we made this change and what was changed_
+- [ ] [ClickUp](https://app.clickup.com/t/XXXXXX)
+- [ ] [Figma](https://www.figma.com/file/XXXXXX)
 
-### Demo
+## ⬅️ As Is
 
-_Add relevant screenshots or demo GIFs_
+Explain the current situation of the code
 
-| Before | After |
-| --- | --- |
-| *img or gif* | *img or gif* |
+- Example1) New SGI and custom item flow required but don't have this implementation yet
+- Example2) No basic inpage for new client
 
-### Ticket
+## ➡️ To Be
 
-_Ticket link, if applicable_
+- [ ] Example1) Create SGI and custom item for new client
+- [ ] Example2) Create basic inpage for new client with hardcoding for external product ID
+
+## ☑️ Checklist
+
+- [ ] Useless comments and/or `Log.d` etc are **removed**
+- [ ] Unit test are **covered**
+- [ ] Code has been **deployed and tested** on STG
+- [ ] ClickUp ticket status has been **updated** to `production`
+- [ ] Update CHANGELOG.md with the new changes

--- a/sampleappcompose/src/main/java/com/virtusize/sampleapp/compose/VirtusizeSampleApp.kt
+++ b/sampleappcompose/src/main/java/com/virtusize/sampleapp/compose/VirtusizeSampleApp.kt
@@ -15,7 +15,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import com.virtusize.android.compose.theme.VirtusizeColors
 import com.virtusize.android.compose.ui.VirtusizeButton
-import com.virtusize.android.compose.ui.VirtusizeButtonColors
+import com.virtusize.android.compose.ui.VirtusizeButtonDefaults
 import com.virtusize.android.data.local.VirtusizeProduct
 
 @Composable
@@ -42,7 +42,7 @@ internal fun VirtusizeSampleApp() {
                 product = product,
                 modifier = Modifier.align(Alignment.CenterHorizontally),
                 colors =
-                    VirtusizeButtonColors(
+                    VirtusizeButtonDefaults.colors(
                         containerColor = VirtusizeColors.Black,
                         contentColor = VirtusizeColors.White,
                     ),

--- a/sampleappcompose/src/main/java/com/virtusize/sampleapp/compose/VirtusizeSampleApp.kt
+++ b/sampleappcompose/src/main/java/com/virtusize/sampleapp/compose/VirtusizeSampleApp.kt
@@ -12,8 +12,8 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.tooling.preview.Preview
+import com.virtusize.android.compose.theme.VirtusizeColors
 import com.virtusize.android.compose.ui.VirtusizeButton
 import com.virtusize.android.compose.ui.VirtusizeButtonColors
 import com.virtusize.android.data.local.VirtusizeProduct
@@ -22,7 +22,10 @@ import com.virtusize.android.data.local.VirtusizeProduct
 internal fun VirtusizeSampleApp() {
     Scaffold(modifier = Modifier.fillMaxSize()) { innerPadding ->
         Column(
-            modifier = Modifier.fillMaxSize().padding(innerPadding),
+            modifier =
+                Modifier
+                    .fillMaxSize()
+                    .padding(innerPadding),
             verticalArrangement = Arrangement.Center,
             horizontalAlignment = Alignment.CenterHorizontally,
         ) {
@@ -40,8 +43,8 @@ internal fun VirtusizeSampleApp() {
                 modifier = Modifier.align(Alignment.CenterHorizontally),
                 colors =
                     VirtusizeButtonColors(
-                        containerColor = Color.Black,
-                        contentColor = Color.White,
+                        containerColor = VirtusizeColors.Black,
+                        contentColor = VirtusizeColors.White,
                     ),
                 onEvent = { event ->
                     Log.i(VIRTUSIZE_BUTTON_TAG, event.name)

--- a/sampleappcompose/src/main/java/com/virtusize/sampleapp/compose/VirtusizeSampleApp.kt
+++ b/sampleappcompose/src/main/java/com/virtusize/sampleapp/compose/VirtusizeSampleApp.kt
@@ -12,8 +12,10 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.tooling.preview.Preview
 import com.virtusize.android.compose.ui.VirtusizeButton
+import com.virtusize.android.compose.ui.VirtusizeButtonColors
 import com.virtusize.android.data.local.VirtusizeProduct
 
 @Composable
@@ -36,6 +38,11 @@ internal fun VirtusizeSampleApp() {
             VirtusizeButton(
                 product = product,
                 modifier = Modifier.align(Alignment.CenterHorizontally),
+                colors =
+                    VirtusizeButtonColors(
+                        containerColor = Color.Black,
+                        contentColor = Color.White,
+                    ),
                 onEvent = { event ->
                     Log.i(VIRTUSIZE_BUTTON_TAG, event.name)
                 },

--- a/virtusize/src/main/java/com/virtusize/android/compose/theme/VirtusizeColors.kt
+++ b/virtusize/src/main/java/com/virtusize/android/compose/theme/VirtusizeColors.kt
@@ -2,10 +2,8 @@ package com.virtusize.android.compose.theme
 
 import androidx.compose.ui.graphics.Color
 
-internal object VirtusizeColors {
+object VirtusizeColors {
     val White = Color(0xFFFFFFFF)
     val Black = Color(0xFF000000)
-    val BrandColor = Color(0xFF16C6BA)
     val Teal = Color(0xFF3ED2BA)
-    val TealPressed = Color(0xAD3ED2BA)
 }

--- a/virtusize/src/main/java/com/virtusize/android/compose/ui/VirtusizeButton.kt
+++ b/virtusize/src/main/java/com/virtusize/android/compose/ui/VirtusizeButton.kt
@@ -77,7 +77,7 @@ fun VirtusizeButton(
  * @param containerColor the container color of this [VirtusizeButton].
  * @param contentColor the content color of this [VirtusizeButton].
  */
-data class VirtusizeButtonColors(
+class VirtusizeButtonColors internal constructor(
     val containerColor: Color,
     val contentColor: Color,
 )

--- a/virtusize/src/main/java/com/virtusize/android/compose/ui/VirtusizeButton.kt
+++ b/virtusize/src/main/java/com/virtusize/android/compose/ui/VirtusizeButton.kt
@@ -1,76 +1,56 @@
 package com.virtusize.android.compose.ui
 
-import androidx.compose.foundation.BorderStroke
-import androidx.compose.foundation.interaction.MutableInteractionSource
-import androidx.compose.foundation.layout.PaddingValues
-import androidx.compose.foundation.layout.RowScope
-import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material3.Button
-import androidx.compose.material3.ButtonDefaults
-import androidx.compose.material3.ButtonElevation
-import androidx.compose.material3.Icon
-import androidx.compose.material3.Text
+import android.graphics.drawable.GradientDrawable
+import android.os.Build
+import androidx.annotation.ColorInt
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.collectAsState
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.Shape
-import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.res.painterResource
-import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.tooling.preview.Preview
-import androidx.compose.ui.unit.Dp
-import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
+import androidx.compose.ui.graphics.toArgb
+import androidx.compose.ui.viewinterop.AndroidView
 import androidx.lifecycle.viewmodel.compose.viewModel
-import com.virtusize.android.R
 import com.virtusize.android.compose.theme.VirtusizeColors
 import com.virtusize.android.data.local.VirtusizeError
 import com.virtusize.android.data.local.VirtusizeEvent
 import com.virtusize.android.data.local.VirtusizeProduct
+import com.virtusize.android.data.local.VirtusizeViewStyle
 import com.virtusize.android.model.VirtusizeMessage
+import com.virtusize.android.ui.VirtusizeButton
+import com.virtusize.android.util.dpInPx
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
 
 @Composable
 fun VirtusizeButton(
     product: VirtusizeProduct,
     modifier: Modifier = Modifier,
-    enabled: Boolean = true,
-    shape: Shape = VirtusizeButtonDefaults.shape,
     colors: VirtusizeButtonColors = VirtusizeButtonDefaults.teal(),
-    elevation: ButtonElevation? = VirtusizeButtonDefaults.buttonElevation(),
-    border: BorderStroke? = null,
-    contentPadding: PaddingValues = VirtusizeButtonDefaults.ContentPadding,
-    interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
     onEvent: (event: VirtusizeEvent) -> Unit = { _ -> },
     onError: (error: VirtusizeError) -> Unit = { _ -> },
-    content: @Composable RowScope.() -> Unit = emptyContent,
 ) {
-    val context = LocalContext.current
-    val viewModel: VirtusizeButtonViewModel = viewModel<VirtusizeButtonViewModel>()
-
-    val state by viewModel.uiStateFlow.collectAsState()
-    VirtusizeButton(
-        state = state,
-        onClick = { viewModel.onButtonClick(context, product) },
+    val viewModel: VirtusizeComposeViewModel = viewModel<VirtusizeComposeViewModel>()
+    val coroutineScope = rememberCoroutineScope()
+    AndroidView(
         modifier = modifier,
-        enabled = enabled,
-        shape = shape,
-        colors = colors,
-        elevation = elevation,
-        border = border,
-        contentPadding = contentPadding,
-        interactionSource = interactionSource,
-        content = content,
+        factory = { context -> VirtusizeButton(context) },
+        update = { virtusizeButton ->
+            viewModel.isLoadedFlow
+                .onEach { isLoaded ->
+                    if (isLoaded) {
+                        virtusizeButton.virtusizeViewStyle = VirtusizeViewStyle.BLACK
+                        virtusizeButton.setRoundedBackgroundColor(colors.containerColor.toArgb())
+                        colors.contentColor.toArgb().apply {
+                            virtusizeButton.setLogoTint(this)
+                            virtusizeButton.setTextColor(this)
+                        }
+                    }
+                }
+                .launchIn(coroutineScope)
+            viewModel.load(product = product, virtusizeView = virtusizeButton)
+        },
     )
-
-    LaunchedEffect(product) {
-        viewModel.loadProduct(product)
-    }
 
     LaunchedEffect(Unit) {
         viewModel.messageFlow.collect { message ->
@@ -82,119 +62,58 @@ fun VirtusizeButton(
     }
 }
 
-@Composable
-private fun VirtusizeButton(
-    state: VirtusizeButtonUiState,
-    onClick: () -> Unit,
-    modifier: Modifier = Modifier,
-    enabled: Boolean = true,
-    shape: Shape = ButtonDefaults.shape,
-    colors: VirtusizeButtonColors = VirtusizeButtonDefaults.teal(),
-    elevation: ButtonElevation? = ButtonDefaults.buttonElevation(),
-    border: BorderStroke? = null,
-    contentPadding: PaddingValues = ButtonDefaults.ContentPadding,
-    interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
-    content: @Composable RowScope.() -> Unit = emptyContent,
+private fun VirtusizeButton.setRoundedBackgroundColor(
+    @ColorInt backgroundColor: Int,
 ) {
-    if (state == VirtusizeButtonUiState.Loaded) {
-        Button(
-            onClick = onClick,
-            modifier = modifier,
-            enabled = enabled,
-            shape = shape,
-            colors =
-                ButtonDefaults.buttonColors(
-                    containerColor = colors.containerColor,
-                    contentColor = colors.contentColor,
-                    disabledContainerColor = colors.disabledContainerColor,
-                    disabledContentColor = colors.disabledContentColor,
-                ),
-            elevation = elevation,
-            border = border,
-            contentPadding = contentPadding,
-            interactionSource = interactionSource,
-        ) {
-            if (content == emptyContent) {
-                Icon(
-                    painter = painterResource(id = R.drawable.ic_vs_icon_white),
-                    contentDescription = null,
-                    modifier = Modifier.size(width = 18.dp, height = 13.dp),
-                )
-                Spacer(modifier = Modifier.size(5.dp))
-                Text(
-                    text = stringResource(id = R.string.virtusize_button_text),
-                    fontSize = 14.sp,
-                )
-            } else {
-                content()
-            }
-        }
+    val shape = GradientDrawable()
+    shape.shape = GradientDrawable.RECTANGLE
+    shape.cornerRadii =
+        floatArrayOf(
+            32.dpInPx.toFloat(),
+            32.dpInPx.toFloat(),
+            32.dpInPx.toFloat(),
+            32.dpInPx.toFloat(),
+            32.dpInPx.toFloat(),
+            32.dpInPx.toFloat(),
+            32.dpInPx.toFloat(),
+            32.dpInPx.toFloat(),
+        )
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+        shape.setPadding(12.dpInPx, 10.dpInPx, 12.dpInPx, 10.dpInPx)
     }
+    shape.setColor(backgroundColor)
+    background = shape
 }
 
-object VirtusizeButtonDefaults {
-    val ContentPadding = PaddingValues(horizontal = 12.dp, vertical = 10.dp)
+private fun VirtusizeButton.setLogoTint(
+    @ColorInt iconTint: Int,
+) {
+    compoundDrawables.getOrNull(0)?.setTint(iconTint)
+}
 
-    val shape: Shape @Composable get() = RoundedCornerShape(32.0.dp)
+data class VirtusizeButtonColors(
+    val containerColor: Color,
+    val contentColor: Color,
+)
 
-    @Composable
-    fun buttonElevation(
-        defaultElevation: Dp = Dp.Unspecified,
-        pressedElevation: Dp = Dp.Unspecified,
-        focusedElevation: Dp = Dp.Unspecified,
-        hoveredElevation: Dp = Dp.Unspecified,
-        disabledElevation: Dp = Dp.Unspecified,
-    ) = ButtonDefaults.buttonElevation(
-        defaultElevation = defaultElevation,
-        pressedElevation = pressedElevation,
-        focusedElevation = focusedElevation,
-        hoveredElevation = hoveredElevation,
-        disabledElevation = disabledElevation,
-    )
-
+internal object VirtusizeButtonDefaults {
     @Composable
     fun teal(
         containerColor: Color = VirtusizeColors.Teal,
         contentColor: Color = VirtusizeColors.White,
-        disabledContainerColor: Color = Color.Unspecified,
-        disabledContentColor: Color = Color.Unspecified,
     ): VirtusizeButtonColors =
         VirtusizeButtonColors(
             containerColor = containerColor,
             contentColor = contentColor,
-            disabledContainerColor = disabledContainerColor,
-            disabledContentColor = disabledContentColor,
         )
 
     @Composable
     fun black(
         containerColor: Color = VirtusizeColors.Black,
         contentColor: Color = VirtusizeColors.White,
-        disabledContainerColor: Color = Color.Unspecified,
-        disabledContentColor: Color = Color.Unspecified,
     ): VirtusizeButtonColors =
         VirtusizeButtonColors(
             containerColor = containerColor,
             contentColor = contentColor,
-            disabledContainerColor = disabledContainerColor,
-            disabledContentColor = disabledContentColor,
         )
-}
-
-data class VirtusizeButtonColors(
-    val containerColor: Color,
-    val contentColor: Color,
-    val disabledContainerColor: Color,
-    val disabledContentColor: Color,
-)
-
-private val emptyContent: @Composable RowScope.() -> Unit = {}
-
-@Composable
-@Preview
-private fun VirtusizeButtonPreview() {
-    VirtusizeButton(
-        state = VirtusizeButtonUiState.Loaded,
-        onClick = {},
-    )
 }

--- a/virtusize/src/main/java/com/virtusize/android/compose/ui/VirtusizeButton.kt
+++ b/virtusize/src/main/java/com/virtusize/android/compose/ui/VirtusizeButton.kt
@@ -27,9 +27,9 @@ import com.virtusize.android.data.local.VirtusizeEvent
 import com.virtusize.android.data.local.VirtusizeProduct
 import com.virtusize.android.data.local.VirtusizeViewStyle
 import com.virtusize.android.model.VirtusizeMessage
+import com.virtusize.android.ui.VirtusizeButton
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
-import com.virtusize.android.ui.VirtusizeButton as AndroidViewVirtusizeButton
 
 /**
  * A composable that displays the VirtusizeButton
@@ -82,12 +82,12 @@ fun VirtusizeButton(
 private fun VirtusizeButton(
     modifier: Modifier = Modifier,
     style: VirtusizeViewStyle = VirtusizeViewStyle.BLACK,
-    update: (AndroidViewVirtusizeButton) -> Unit = NoOpUpdate,
+    update: (VirtusizeButton) -> Unit = NoOpUpdate,
 ) {
     AndroidView(
         modifier = modifier,
         factory = { context ->
-            AndroidViewVirtusizeButton(context)
+            VirtusizeButton(context)
         },
         update = { virtusizeButton ->
             virtusizeButton.virtusizeViewStyle = style
@@ -151,7 +151,7 @@ object VirtusizeButtonDefaults {
  * A extension function to set rounded corner background of the [VirtusizeButton].
  * @param backgroundColor The color to be set as the background of the [VirtusizeButton].
  */
-private fun AndroidViewVirtusizeButton.setRoundedCornerBackground(
+private fun VirtusizeButton.setRoundedCornerBackground(
     @ColorInt backgroundColor: Int,
 ) {
     val drawable = GradientDrawable()
@@ -192,7 +192,7 @@ private fun AndroidViewVirtusizeButton.setRoundedCornerBackground(
 /**
  * A extension function to specify the Virtusize logo tint color of the [VirtusizeButton].
  */
-private fun AndroidViewVirtusizeButton.setVirtusizeLogoTint(
+private fun VirtusizeButton.setVirtusizeLogoTint(
     @ColorInt iconTint: Int,
 ) {
     compoundDrawables.getOrNull(0)?.setTint(iconTint)
@@ -202,7 +202,7 @@ private fun AndroidViewVirtusizeButton.setVirtusizeLogoTint(
 @Preview
 private fun VirtusizeButtonPreview() {
     Column(verticalArrangement = Arrangement.spacedBy(16.dp)) {
-        val update: (AndroidViewVirtusizeButton) -> Unit = { virtusizeButton ->
+        val update: (VirtusizeButton) -> Unit = { virtusizeButton ->
             virtusizeButton.text = virtusizeButton.context.resources.getText(R.string.virtusize_button_text)
             virtusizeButton.visibility = View.VISIBLE
         }

--- a/virtusize/src/main/java/com/virtusize/android/compose/ui/VirtusizeButton.kt
+++ b/virtusize/src/main/java/com/virtusize/android/compose/ui/VirtusizeButton.kt
@@ -25,7 +25,7 @@ import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 
 /**
- * A button composable that displays the Virtusize button
+ * A composable that displays the VirtusizeButton
  * @param product The product to be linked with the button.
  * @param modifier The modifier to be applied to the button layout.
  * @param colors The colors to be applied to the button.

--- a/virtusize/src/main/java/com/virtusize/android/compose/ui/VirtusizeButton.kt
+++ b/virtusize/src/main/java/com/virtusize/android/compose/ui/VirtusizeButton.kt
@@ -6,6 +6,7 @@ import android.graphics.drawable.LayerDrawable
 import android.os.Build
 import androidx.annotation.ColorInt
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.Immutable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Modifier
@@ -77,7 +78,8 @@ fun VirtusizeButton(
  * @param containerColor the container color of this [VirtusizeButton].
  * @param contentColor the content color of this [VirtusizeButton].
  */
-class VirtusizeButtonColors internal constructor(
+@Immutable
+data class VirtusizeButtonColors internal constructor(
     val containerColor: Color,
     val contentColor: Color,
 )

--- a/virtusize/src/main/java/com/virtusize/android/compose/ui/VirtusizeButton.kt
+++ b/virtusize/src/main/java/com/virtusize/android/compose/ui/VirtusizeButton.kt
@@ -1,6 +1,8 @@
 package com.virtusize.android.compose.ui
 
+import android.graphics.drawable.Drawable
 import android.graphics.drawable.GradientDrawable
+import android.graphics.drawable.LayerDrawable
 import android.os.Build
 import androidx.annotation.ColorInt
 import androidx.compose.runtime.Composable
@@ -11,6 +13,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.viewinterop.AndroidView
 import androidx.lifecycle.viewmodel.compose.viewModel
+import com.virtusize.android.R
 import com.virtusize.android.compose.theme.VirtusizeColors
 import com.virtusize.android.data.local.VirtusizeError
 import com.virtusize.android.data.local.VirtusizeEvent
@@ -18,10 +21,17 @@ import com.virtusize.android.data.local.VirtusizeProduct
 import com.virtusize.android.data.local.VirtusizeViewStyle
 import com.virtusize.android.model.VirtusizeMessage
 import com.virtusize.android.ui.VirtusizeButton
-import com.virtusize.android.util.dpInPx
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 
+/**
+ * A button composable that displays the Virtusize button
+ * @param product The product to be linked with the button.
+ * @param modifier The modifier to be applied to the button layout.
+ * @param colors The colors to be applied to the button.
+ * @param onEvent The callback to be invoked when an [VirtusizeEvent] is triggered.
+ * @param onError The callback to be invoked when an [VirtusizeError] is triggered.
+ */
 @Composable
 fun VirtusizeButton(
     product: VirtusizeProduct,
@@ -40,9 +50,9 @@ fun VirtusizeButton(
                 .onEach { isLoaded ->
                     if (isLoaded) {
                         virtusizeButton.virtusizeViewStyle = VirtusizeViewStyle.BLACK
-                        virtusizeButton.setRoundedBackgroundColor(colors.containerColor.toArgb())
+                        virtusizeButton.setRoundedCornerBackground(colors.containerColor.toArgb())
                         colors.contentColor.toArgb().apply {
-                            virtusizeButton.setLogoTint(this)
+                            virtusizeButton.setVirtusizeLogoTint(this)
                             virtusizeButton.setTextColor(this)
                         }
                     }
@@ -62,58 +72,96 @@ fun VirtusizeButton(
     }
 }
 
-private fun VirtusizeButton.setRoundedBackgroundColor(
-    @ColorInt backgroundColor: Int,
-) {
-    val shape = GradientDrawable()
-    shape.shape = GradientDrawable.RECTANGLE
-    shape.cornerRadii =
-        floatArrayOf(
-            32.dpInPx.toFloat(),
-            32.dpInPx.toFloat(),
-            32.dpInPx.toFloat(),
-            32.dpInPx.toFloat(),
-            32.dpInPx.toFloat(),
-            32.dpInPx.toFloat(),
-            32.dpInPx.toFloat(),
-            32.dpInPx.toFloat(),
-        )
-    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
-        shape.setPadding(12.dpInPx, 10.dpInPx, 12.dpInPx, 10.dpInPx)
-    }
-    shape.setColor(backgroundColor)
-    background = shape
-}
-
-private fun VirtusizeButton.setLogoTint(
-    @ColorInt iconTint: Int,
-) {
-    compoundDrawables.getOrNull(0)?.setTint(iconTint)
-}
-
+/**
+ * Represents the container and content colors used in a [VirtusizeButton].
+ * @param containerColor the container color of this [VirtusizeButton].
+ * @param contentColor the content color of this [VirtusizeButton].
+ */
 data class VirtusizeButtonColors(
     val containerColor: Color,
     val contentColor: Color,
 )
 
-internal object VirtusizeButtonDefaults {
+/**
+ * Contains the default values used by [VirtusizeButton].
+ */
+object VirtusizeButtonDefaults {
+    /**
+     * Creates a [VirtusizeButtonColors] that represents the default container and content colors used for the [teal] style.
+     */
     @Composable
-    fun teal(
-        containerColor: Color = VirtusizeColors.Teal,
-        contentColor: Color = VirtusizeColors.White,
-    ): VirtusizeButtonColors =
+    fun teal(): VirtusizeButtonColors =
         VirtusizeButtonColors(
-            containerColor = containerColor,
-            contentColor = contentColor,
+            containerColor = VirtusizeColors.Teal,
+            contentColor = VirtusizeColors.White,
         )
 
+    /**
+     * Creates a [VirtusizeButtonColors] that represents the default container and content colors used for the [black] style.
+     */
     @Composable
-    fun black(
-        containerColor: Color = VirtusizeColors.Black,
-        contentColor: Color = VirtusizeColors.White,
+    fun black(): VirtusizeButtonColors =
+        VirtusizeButtonColors(
+            containerColor = VirtusizeColors.Black,
+            contentColor = VirtusizeColors.White,
+        )
+
+    /**
+     * Creates a [VirtusizeButtonColors] that represents the default container and content colors used in a [VirtusizeButton].
+     * @param containerColor the container color of this [VirtusizeButton].
+     * @param contentColor the content color of this [VirtusizeButton].
+     */
+    @Composable
+    fun colors(
+        containerColor: Color = Color.Unspecified,
+        contentColor: Color = Color.Unspecified,
     ): VirtusizeButtonColors =
         VirtusizeButtonColors(
             containerColor = containerColor,
             contentColor = contentColor,
         )
+}
+
+/**
+ * A extension function to set rounded corner background of the [VirtusizeButton].
+ * @param backgroundColor The color to be set as the background of the [VirtusizeButton].
+ */
+private fun VirtusizeButton.setRoundedCornerBackground(
+    @ColorInt backgroundColor: Int,
+) {
+    val drawable = GradientDrawable()
+    drawable.shape = GradientDrawable.RECTANGLE
+    val cornerRadius = resources.getDimension(R.dimen.virtusize_button_corner_radius)
+    drawable.cornerRadii =
+        floatArrayOf(
+            cornerRadius,
+            cornerRadius,
+            cornerRadius,
+            cornerRadius,
+            cornerRadius,
+            cornerRadius,
+            cornerRadius,
+            cornerRadius,
+        )
+    drawable.setColor(backgroundColor)
+    val verticalPadding = resources.getDimension(R.dimen.virtusize_button_vertical_padding).toInt()
+    val horizontalPadding = resources.getDimension(R.dimen.virtusize_button_horizontal_padding).toInt()
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+        drawable.setPadding(horizontalPadding, verticalPadding, horizontalPadding, verticalPadding)
+        background = drawable
+    } else {
+        val layers = arrayOf<Drawable>(drawable)
+        val layerDrawable = LayerDrawable(layers)
+        layerDrawable.setLayerInset(0, horizontalPadding, verticalPadding, horizontalPadding, verticalPadding)
+        background = layerDrawable.getDrawable(0)
+    }
+}
+
+/**
+ * A extension function to specify the Virtusize logo tint color of the [VirtusizeButton].
+ */
+private fun VirtusizeButton.setVirtusizeLogoTint(
+    @ColorInt iconTint: Int,
+) {
+    compoundDrawables.getOrNull(0)?.setTint(iconTint)
 }

--- a/virtusize/src/main/java/com/virtusize/android/compose/ui/wip/VirtusizeButtonUiState.kt
+++ b/virtusize/src/main/java/com/virtusize/android/compose/ui/wip/VirtusizeButtonUiState.kt
@@ -1,4 +1,4 @@
-package com.virtusize.android.compose.ui
+package com.virtusize.android.compose.ui.wip
 
 internal sealed interface VirtusizeButtonUiState {
     data object Idle : VirtusizeButtonUiState

--- a/virtusize/src/main/java/com/virtusize/android/compose/ui/wip/VirtusizeButtonViewModel.kt
+++ b/virtusize/src/main/java/com/virtusize/android/compose/ui/wip/VirtusizeButtonViewModel.kt
@@ -1,0 +1,79 @@
+package com.virtusize.android.compose.ui.wip
+
+import android.content.Context
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.virtusize.android.Virtusize
+import com.virtusize.android.data.local.VirtusizeError
+import com.virtusize.android.data.local.VirtusizeEvent
+import com.virtusize.android.data.local.VirtusizeMessageHandler
+import com.virtusize.android.data.local.VirtusizeProduct
+import com.virtusize.android.model.VirtusizeMessage
+import com.virtusize.android.util.VirtusizeUtils
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.receiveAsFlow
+import kotlinx.coroutines.launch
+
+internal class VirtusizeButtonViewModel : ViewModel() {
+    private val mutableUiStateFlow by lazy {
+        MutableStateFlow<VirtusizeButtonUiState>(
+            VirtusizeButtonUiState.Idle,
+        )
+    }
+    val uiStateFlow: StateFlow<VirtusizeButtonUiState> = mutableUiStateFlow.asStateFlow()
+
+    private val mutableMessageFlow: Channel<VirtusizeMessage> by lazy { Channel() }
+    val messageFlow = mutableMessageFlow.receiveAsFlow()
+
+    private val virtusize: Virtusize by lazy { Virtusize.getInstance() }
+
+    private val messageHandler =
+        object : VirtusizeMessageHandler {
+            override fun onEvent(
+                product: VirtusizeProduct,
+                event: VirtusizeEvent,
+            ) {
+                mutableMessageFlow.trySend(VirtusizeMessage.Event(product, event))
+            }
+
+            override fun onError(error: VirtusizeError) {
+                mutableMessageFlow.trySend(VirtusizeMessage.Error(error))
+            }
+        }
+
+    init {
+        virtusize.registerMessageHandler(messageHandler)
+    }
+
+    fun loadProduct(product: VirtusizeProduct) {
+        viewModelScope.launch {
+            mutableUiStateFlow.tryEmit(VirtusizeButtonUiState.Loading)
+            val isProductValid = virtusize.productDataCheck(product)
+            if (isProductValid) {
+                mutableUiStateFlow.tryEmit(VirtusizeButtonUiState.Loaded)
+            } else {
+                mutableUiStateFlow.tryEmit(VirtusizeButtonUiState.Idle)
+            }
+        }
+    }
+
+    fun onButtonClick(
+        context: Context,
+        product: VirtusizeProduct,
+    ) {
+        VirtusizeUtils.openVirtusizeWebView(
+            context,
+            virtusize.params,
+            product,
+            messageHandler,
+        )
+    }
+
+    override fun onCleared() {
+        super.onCleared()
+        virtusize.unregisterMessageHandler(messageHandler)
+    }
+}

--- a/virtusize/src/main/java/com/virtusize/android/compose/ui/wip/WIPVirtusizeButton.kt
+++ b/virtusize/src/main/java/com/virtusize/android/compose/ui/wip/WIPVirtusizeButton.kt
@@ -1,0 +1,149 @@
+package com.virtusize.android.compose.ui.wip
+
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.RowScope
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.ButtonElevation
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Shape
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.lifecycle.viewmodel.compose.viewModel
+import com.virtusize.android.R
+import com.virtusize.android.compose.ui.VirtusizeButtonColors
+import com.virtusize.android.compose.ui.VirtusizeButtonDefaults
+import com.virtusize.android.data.local.VirtusizeError
+import com.virtusize.android.data.local.VirtusizeEvent
+import com.virtusize.android.data.local.VirtusizeProduct
+import com.virtusize.android.model.VirtusizeMessage
+
+@Composable
+private fun VirtusizeButton(
+    product: VirtusizeProduct,
+    modifier: Modifier = Modifier,
+    colors: VirtusizeButtonColors = VirtusizeButtonDefaults.teal(),
+    onEvent: (event: VirtusizeEvent) -> Unit = { _ -> },
+    onError: (error: VirtusizeError) -> Unit = { _ -> },
+) {
+    val context = LocalContext.current
+    val viewModel: VirtusizeButtonViewModel = viewModel<VirtusizeButtonViewModel>()
+
+    val state by viewModel.uiStateFlow.collectAsState()
+    VirtusizeButton(
+        state = state,
+        onClick = { viewModel.onButtonClick(context, product) },
+        modifier = modifier,
+        colors = colors,
+    )
+
+    LaunchedEffect(product) {
+        viewModel.loadProduct(product)
+    }
+
+    LaunchedEffect(Unit) {
+        viewModel.messageFlow.collect { message ->
+            when (message) {
+                is VirtusizeMessage.Event -> onEvent(message.event)
+                is VirtusizeMessage.Error -> onError(message.error)
+            }
+        }
+    }
+}
+
+@Composable
+private fun VirtusizeButton(
+    state: VirtusizeButtonUiState,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    enabled: Boolean = true,
+    shape: Shape = WIPVirtusizeButtonDefaults.shape,
+    colors: VirtusizeButtonColors = VirtusizeButtonDefaults.teal(),
+    elevation: ButtonElevation? = WIPVirtusizeButtonDefaults.buttonElevation(),
+    border: BorderStroke? = null,
+    contentPadding: PaddingValues = WIPVirtusizeButtonDefaults.ContentPadding,
+    interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
+    content: @Composable RowScope.() -> Unit = emptyContent,
+) {
+    if (state == VirtusizeButtonUiState.Loaded) {
+        Button(
+            onClick = onClick,
+            modifier = modifier,
+            enabled = enabled,
+            shape = shape,
+            colors =
+                ButtonDefaults.buttonColors(
+                    containerColor = colors.containerColor,
+                    contentColor = colors.contentColor,
+                ),
+            elevation = elevation,
+            border = border,
+            contentPadding = contentPadding,
+            interactionSource = interactionSource,
+        ) {
+            if (content == emptyContent) {
+                Icon(
+                    painter = painterResource(id = R.drawable.ic_vs_icon_white),
+                    contentDescription = null,
+                    modifier = Modifier.size(width = 18.dp, height = 13.dp),
+                )
+                Spacer(modifier = Modifier.size(5.dp))
+                Text(
+                    text = stringResource(id = R.string.virtusize_button_text),
+                    fontSize = 14.sp,
+                )
+            } else {
+                content()
+            }
+        }
+    }
+}
+
+private object WIPVirtusizeButtonDefaults {
+    val ContentPadding = PaddingValues(horizontal = 12.dp, vertical = 10.dp)
+
+    val shape: Shape @Composable get() = RoundedCornerShape(32.0.dp)
+
+    @Composable
+    fun buttonElevation(
+        defaultElevation: Dp = Dp.Unspecified,
+        pressedElevation: Dp = Dp.Unspecified,
+        focusedElevation: Dp = Dp.Unspecified,
+        hoveredElevation: Dp = Dp.Unspecified,
+        disabledElevation: Dp = Dp.Unspecified,
+    ) = ButtonDefaults.buttonElevation(
+        defaultElevation = defaultElevation,
+        pressedElevation = pressedElevation,
+        focusedElevation = focusedElevation,
+        hoveredElevation = hoveredElevation,
+        disabledElevation = disabledElevation,
+    )
+}
+
+private val emptyContent: @Composable RowScope.() -> Unit = {}
+
+@Composable
+@Preview
+private fun WIPVirtusizeButtonPreview() {
+    VirtusizeButton(
+        state = VirtusizeButtonUiState.Loaded,
+        onClick = {},
+    )
+}

--- a/virtusize/src/main/java/com/virtusize/android/flutter/VirtusizeFlutterUtils.kt
+++ b/virtusize/src/main/java/com/virtusize/android/flutter/VirtusizeFlutterUtils.kt
@@ -13,7 +13,6 @@ import com.virtusize.android.data.remote.BodyProfileRecommendedSize
 import com.virtusize.android.data.remote.I18nLocalization
 import com.virtusize.android.data.remote.Product
 import com.virtusize.android.data.remote.ProductType
-import com.virtusize.android.ui.VirtusizeWebViewFragment
 import com.virtusize.android.util.VirtusizeUtils
 import com.virtusize.android.util.trimI18nText
 
@@ -27,7 +26,6 @@ object VirtusizeFlutterUtils {
         VirtusizeUtils.openVirtusizeWebView(
             activity,
             virtusize?.params,
-            VirtusizeWebViewFragment(),
             product,
             messageHandler,
         )

--- a/virtusize/src/main/java/com/virtusize/android/ui/VirtusizeView.kt
+++ b/virtusize/src/main/java/com/virtusize/android/ui/VirtusizeView.kt
@@ -72,7 +72,6 @@ interface VirtusizeView {
         VirtusizeUtils.openVirtusizeWebView(
             context,
             virtusizeParams,
-            virtusizeDialogFragment,
             product,
             virtusizeMessageHandler,
         )

--- a/virtusize/src/main/java/com/virtusize/android/util/VirtusizeUtils.kt
+++ b/virtusize/src/main/java/com/virtusize/android/util/VirtusizeUtils.kt
@@ -6,7 +6,6 @@ import android.content.Intent
 import android.os.Build
 import android.os.Bundle
 import android.os.LocaleList
-import androidx.fragment.app.FragmentActivity
 import com.virtusize.android.data.local.ProductComparisonFitInfo
 import com.virtusize.android.data.local.SizeComparisonRecommendedSize
 import com.virtusize.android.data.local.VirtusizeLanguage
@@ -20,7 +19,6 @@ import com.virtusize.android.data.remote.ProductType
 import com.virtusize.android.data.remote.Weight
 import com.virtusize.android.network.VirtusizeApi
 import com.virtusize.android.ui.VirtusizeWebViewActivity
-import com.virtusize.android.ui.VirtusizeWebViewFragment
 import java.util.Locale
 import kotlin.math.abs
 
@@ -159,24 +157,6 @@ internal object VirtusizeUtils {
     /**
      * A function to open the Virtusize WebView
      */
-    fun openVirtusizeWebView(
-        context: Context,
-        virtusizeParams: VirtusizeParams?,
-        virtusizeDialogFragment: VirtusizeWebViewFragment,
-        product: VirtusizeProduct,
-        messageHandler: VirtusizeMessageHandler,
-    ) {
-        val fragmentTransaction = (context as FragmentActivity).supportFragmentManager.beginTransaction()
-        val previousFragment = context.supportFragmentManager.findFragmentByTag(Constants.FRAG_TAG)
-        previousFragment?.let { fragment ->
-            fragmentTransaction.remove(fragment)
-        }
-        fragmentTransaction.addToBackStack(null)
-        virtusizeDialogFragment.arguments = createBundle(virtusizeParams, product)
-        virtusizeDialogFragment.setupMessageHandler(messageHandler)
-        virtusizeDialogFragment.show(fragmentTransaction, Constants.FRAG_TAG)
-    }
-
     fun openVirtusizeWebView(
         context: Context,
         virtusizeParams: VirtusizeParams?,


### PR DESCRIPTION
## 🔗 Related Links

- [x] [ClickUp](https://app.clickup.com/t/3702259/NSDK-193)

## ⬅️ As Is

I decided to build the Jetpack Compose wrapper to compose the Android Views (VirtusizeButton, VirtusizeInPage, etc) we already have first before building Jetpack Compose UI components from scratch as it takes more time than expected. 

## ➡️ To Be

- [x] Moved WIP code in the wip package and changed their visibility to private
- [x] Created VirtusizeButton

https://github.com/user-attachments/assets/5d68f2d0-0f8d-4473-8b5b-f08d595dd72d

## ☑️ Checklist

- [x] Useless comments and/or `Log.d` etc are **removed**
- [ ] Unit test are **covered**
- [ ] Code has been **deployed and tested** on STG
- [x] ClickUp ticket status has been **updated** to `DEV REVIEW`
- [ ] Update CHANGELOG.md with the new changes