### PR TITLE
[NSDK-206] Fix an Issue Where the SDK Could Not Retain the Email Login Session

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ### Enhancement
 
-- Remove Japanese link in README-COMPOSE.md
+- Removed Japanese link in README-COMPOSE.md
+- Fixed an issue where the SDK could not retain the email login session.
 
 ## 2.6.0
 

--- a/README-COMPOSE.md
+++ b/README-COMPOSE.md
@@ -248,10 +248,10 @@ There are two default styles of the Virtusize Button in our Virtusize SDK.
 
     ```kotlin
     val product = VirtusizeProduct(
-    // Set the product's external ID
-    externalId = "vs_dress",
-    // Set the product image URL
-    imageUrl = "http://www.image.com/goods/12345.jpg"
+        // Set the product's external ID
+        externalId = "vs_dress",
+        // Set the product image URL
+        imageUrl = "http://www.image.com/goods/12345.jpg"
     )
     ```
 
@@ -314,10 +314,10 @@ There are two types of InPage in our Virtusize SDK.
 
       ```kotlin
       val product = VirtusizeProduct(
-      // Set the product's external ID
-      externalId = "vs_dress",
-      // Set the product image URL
-      imageUrl = "http://www.image.com/goods/12345.jpg"
+          // Set the product's external ID
+          externalId = "vs_dress",
+          // Set the product image URL
+          imageUrl = "http://www.image.com/goods/12345.jpg"
       )
       ```
 
@@ -404,10 +404,10 @@ for layouts where customers are browsing product images and size tables.
 
       ```kotlin
       val product = VirtusizeProduct(
-      // Set the product's external ID
-      externalId = "vs_dress",
-      // Set the product image URL
-      imageUrl = "http://www.image.com/goods/12345.jpg"
+          // Set the product's external ID
+          externalId = "vs_dress",
+          // Set the product image URL
+          imageUrl = "http://www.image.com/goods/12345.jpg"
       )
       ```
 

--- a/sampleappcompose/build.gradle.kts
+++ b/sampleappcompose/build.gradle.kts
@@ -47,10 +47,6 @@ android {
         compose = true
     }
 
-    composeOptions {
-        kotlinCompilerExtensionVersion = "1.5.1"
-    }
-
     packaging {
         resources {
             excludes += "/META-INF/{AL2.0,LGPL2.1}"

--- a/virtusize/build.gradle.kts
+++ b/virtusize/build.gradle.kts
@@ -63,6 +63,10 @@ android {
             // withJavadocJar()
         }
     }
+
+    composeOptions {
+        kotlinCompilerExtensionVersion = "1.5.1"
+    }
 }
 
 dependencies {

--- a/virtusize/src/main/java/com/virtusize/android/VirtusizeImpl.kt
+++ b/virtusize/src/main/java/com/virtusize/android/VirtusizeImpl.kt
@@ -170,23 +170,31 @@ internal class VirtusizeImpl(
         }
 
     /**
+     * The current product external ID
+     */
+    private var currentProductExternalId: String? = null
+
+    /**
      * The VirtusizePresenter handles the data passed from the actions of VirtusizeRepository
      */
     private val virtusizePresenter =
         object : VirtusizePresenter {
-            override fun onValidProductDataCheck(productWithPDC: VirtusizeProduct) {
+            override fun onValidProductDataCheck(productWithPDCData: VirtusizeProduct) {
                 for (virtusizeView in virtusizeViews) {
-                    virtusizeView.setProductWithProductDataCheck(productWithPDC)
+                    virtusizeView.setProductWithProductDataCheck(productWithPDCData)
                 }
-                if (virtusizeViewsContainInPage()) {
-                    scope.launch {
-                        virtusizeRepository.fetchInitialData(params.language, productWithPDC)
-                        virtusizeRepository.updateUserSession(productWithPDC.externalId)
-                        virtusizeRepository.fetchDataForInPageRecommendation(
-                            productWithPDC.externalId,
-                        )
-                        virtusizeRepository.updateInPageRecommendation(productWithPDC.externalId)
+                if (currentProductExternalId != productWithPDCData.externalId) {
+                    if (virtusizeViewsContainInPage()) {
+                        scope.launch {
+                            virtusizeRepository.fetchInitialData(params.language, productWithPDCData)
+                            virtusizeRepository.updateUserSession(productWithPDCData.externalId)
+                            virtusizeRepository.fetchDataForInPageRecommendation(
+                                productWithPDCData.externalId,
+                            )
+                            virtusizeRepository.updateInPageRecommendation(productWithPDCData.externalId)
+                        }
                     }
+                    currentProductExternalId = productWithPDCData.externalId
                 }
             }
 


### PR DESCRIPTION
## 🔗 Related Links

- [x] [ClickUp](https://app.clickup.com/t/3702259/NSDK-206)

## ➡️ To Be

The bug was caused by calling the session API endpoint multiple times for the same product, and somehow it cleared up the current logged-in user session.

- Prevented from calling the same API endpoint multiple times for the same product

https://github.com/user-attachments/assets/4ab2bc18-dd14-42d5-bc54-587805977db2

- Move declaring compose compiler version to the Virtusize module
- Updated README-COMPOSE.md

## ☑️ Checklist

- [x] Useless comments and/or `Log.d` etc are **removed**
- [ ] Unit tests are **covered**
- [ ] Code has been **deployed and tested** on STG
- [x] ClickUp ticket status has been **updated** to `DEV REVIEW`
- [x] Update CHANGELOG.md with the new changes
