### PR TITLE
[NSDK-197] Bump Virtusize Auth SDK to 1.0.6

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,9 +17,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Set up JDK 17
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v4
         with:
           java-version: '17'
           distribution: 'adopt'

--- a/.github/workflows/pull-request-checks.yml
+++ b/.github/workflows/pull-request-checks.yml
@@ -8,9 +8,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Set up JDK 17
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v4
         with:
           java-version: '17'
           distribution: 'adopt'
@@ -26,9 +26,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Set up JDK 17
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v4
         with:
           java-version: '17'
           distribution: 'adopt'
@@ -43,16 +43,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Set up JDK 17
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v4
         with:
           java-version: '17'
           distribution: 'adopt'
           cache: gradle
       - name: Unit tests
         run: ./gradlew testDebugUnitTest
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v4
         if: failure()
         with:
           name: unit-test-report

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Removed Japanese link in README-COMPOSE.md
 - Fixed an issue where the SDK could not retain the email login session.
+- Bump virtusize-auth to 1.0.6
 
 ## 2.6.0
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -17,7 +17,7 @@ nextPublish = "1.1.0"
 robolectric = "4.13"
 truth = "1.4.4"
 virtusize = "2.6.0"
-virtusizeAuth = "1.0.5"
+virtusizeAuth = "1.0.6"
 
 [libraries]
 androidx-activity-compose = { module = "androidx.activity:activity-compose", version.ref = "activityCompose" }

--- a/sampleAppKotlin/build.gradle.kts
+++ b/sampleAppKotlin/build.gradle.kts
@@ -51,6 +51,4 @@ dependencies {
 
 //    implementation(libs.virtusize)
     implementation(project(":virtusize"))
-    // For the WebViewFragment example implementation
-    implementation(libs.virtusize.auth)
 }

--- a/sampleAppKotlin/build.gradle.kts
+++ b/sampleAppKotlin/build.gradle.kts
@@ -51,5 +51,6 @@ dependencies {
 
 //    implementation(libs.virtusize)
     implementation(project(":virtusize"))
+    // For the WebViewFragment example implementation
     implementation(libs.virtusize.auth)
 }

--- a/sampleappcompose/build.gradle.kts
+++ b/sampleappcompose/build.gradle.kts
@@ -65,5 +65,4 @@ dependencies {
 
     //    implementation(libs.virtusize)
     implementation(project(":virtusize"))
-    implementation(libs.virtusize.auth)
 }

--- a/sampleappjava/build.gradle.kts
+++ b/sampleappjava/build.gradle.kts
@@ -47,5 +47,4 @@ dependencies {
 
 //    implementation(libs.virtusize)
     implementation(project(":virtusize"))
-    implementation(libs.virtusize.auth)
 }

--- a/virtusize/build.gradle.kts
+++ b/virtusize/build.gradle.kts
@@ -71,7 +71,9 @@ android {
 
 dependencies {
     api(project(":virtusize-core"))
-    implementation(libs.virtusize.auth)
+    api(libs.virtusize.auth) {
+        exclude(group = "com.virtusize.android", module = "virtusize-core")
+    }
 
     implementation(libs.androidx.appcompat)
     implementation(libs.androidx.core.ktx)

--- a/virtusize/build.gradle.kts
+++ b/virtusize/build.gradle.kts
@@ -71,7 +71,7 @@ android {
 
 dependencies {
     api(project(":virtusize-core"))
-    compileOnly(libs.virtusize.auth)
+    implementation(libs.virtusize.auth)
 
     implementation(libs.androidx.appcompat)
     implementation(libs.androidx.core.ktx)


### PR DESCRIPTION
## 🔗 Related Links

- [x] [ClickUp](https://app.clickup.com/t/3702259/NSDK-197)
- [ ] [Figma](https://www.figma.com/file/XXXXXX)

## ➡️ To Be

As title

## ☑️ Checklist

- [x] Useless comments and/or `Log.d` etc are **removed**
- [ ] Unit test are **covered**
- [ ] Code has been **deployed and tested** on STG
- [ ] ClickUp ticket status has been **updated** to `production`
- [x] Update CHANGELOG.md with the new changes
