### PR TITLE
[NSDK-245] Fix Password Reset Doesn’t Work and WebView Redirection Issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+### Next Release
+* Fix: Password Reset button doesn’t work
+
 ### 2.7.4
 * Fix: Inpage text is not appropriate when the size is recommended
 * Fix: Inpage text for on-boarding user has 2 patterns at random

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ### Next Release
 * Fix: Password Reset button doesn’t work
+* Fix: After the login is succeeded, you can never go back to the app automatically
 
 ### 2.7.4
 * Fix: Inpage text is not appropriate when the size is recommended

--- a/virtusize/src/main/java/com/virtusize/android/ui/VirtusizeWebViewFragment.kt
+++ b/virtusize/src/main/java/com/virtusize/android/ui/VirtusizeWebViewFragment.kt
@@ -149,47 +149,49 @@ class VirtusizeWebViewFragment : DialogFragment() {
                     resultMsg: Message,
                 ): Boolean {
                     if (resultMsg.obj != null && resultMsg.obj is WebView.WebViewTransport) {
-                        val popupWebView = WebView(view.context).apply {
-                            setBackgroundColor(Color.TRANSPARENT)
-                            layoutParams = ViewGroup.LayoutParams(
-                                ViewGroup.LayoutParams.MATCH_PARENT,
-                                ViewGroup.LayoutParams.MATCH_PARENT,
-                            )
-                            settings.javaScriptEnabled = true
-                            settings.javaScriptCanOpenWindowsAutomatically = true
-                            settings.setSupportMultipleWindows(true)
-                            settings.userAgentString = System.getProperty("http.agent")
-                            webViewClient =
-                                object : WebViewClient() {
-                                    override fun shouldOverrideUrlLoading(
-                                        view: WebView,
-                                        url: String,
-                                    ): Boolean {
-                                        if (VirtusizeURLCheck.isExternalLinkFromVirtusize(url)) {
-                                            val intent = Intent(Intent.ACTION_VIEW, Uri.parse(url))
-                                            try {
-                                                startActivity(intent)
-                                            } finally {
-                                                return true
+                        val popupWebView =
+                            WebView(view.context).apply {
+                                setBackgroundColor(Color.TRANSPARENT)
+                                layoutParams =
+                                    ViewGroup.LayoutParams(
+                                        ViewGroup.LayoutParams.MATCH_PARENT,
+                                        ViewGroup.LayoutParams.MATCH_PARENT,
+                                    )
+                                settings.javaScriptEnabled = true
+                                settings.javaScriptCanOpenWindowsAutomatically = true
+                                settings.setSupportMultipleWindows(true)
+                                settings.userAgentString = System.getProperty("http.agent")
+                                webViewClient =
+                                    object : WebViewClient() {
+                                        override fun shouldOverrideUrlLoading(
+                                            view: WebView,
+                                            url: String,
+                                        ): Boolean {
+                                            if (VirtusizeURLCheck.isExternalLinkFromVirtusize(url)) {
+                                                val intent = Intent(Intent.ACTION_VIEW, Uri.parse(url))
+                                                try {
+                                                    startActivity(intent)
+                                                } finally {
+                                                    return true
+                                                }
                                             }
+                                            if (showSNSButtons) {
+                                                return VirtusizeAuth.isSNSAuthUrl(
+                                                    requireContext(),
+                                                    virtusizeSNSAuthLauncher,
+                                                    url,
+                                                )
+                                            }
+                                            return false
                                         }
-                                        if (showSNSButtons) {
-                                            return VirtusizeAuth.isSNSAuthUrl(
-                                                requireContext(),
-                                                virtusizeSNSAuthLauncher,
-                                                url,
-                                            )
+                                    }
+                                webChromeClient =
+                                    object : WebChromeClient() {
+                                        override fun onCloseWindow(window: WebView) {
+                                            binding.webView.removeAllViews()
                                         }
-                                        return false
                                     }
-                                }
-                            webChromeClient =
-                                object : WebChromeClient() {
-                                    override fun onCloseWindow(window: WebView) {
-                                        binding.webView.removeAllViews()
-                                    }
-                                }
-                        }
+                            }
 
                         val transport = resultMsg.obj as WebView.WebViewTransport
                         binding.webView.addView(popupWebView)

--- a/virtusize/src/main/java/com/virtusize/android/ui/VirtusizeWebViewFragment.kt
+++ b/virtusize/src/main/java/com/virtusize/android/ui/VirtusizeWebViewFragment.kt
@@ -160,6 +160,7 @@ class VirtusizeWebViewFragment : DialogFragment() {
                                 settings.javaScriptEnabled = true
                                 settings.javaScriptCanOpenWindowsAutomatically = true
                                 settings.setSupportMultipleWindows(true)
+                                settings.setDomStorageEnabled(true)
                                 settings.userAgentString = System.getProperty("http.agent")
                                 webViewClient =
                                     object : WebViewClient() {


### PR DESCRIPTION
## 🔗 Related Links

- [x] [ClickUp](https://app.clickup.com/t/3702259/NSDK-245)

## ⬅️ As Is

https://docs.google.com/presentation/d/1Cloxn7s0hsTMIDfznjPfBuXqAXMQUjXgKIwgyjoqk9c/edit#slide=id.g3210edc6694_0_5
- Password Reset button doesn’t work
- After the login is succeeded, you can never go back to the app automatically

## ➡️ To Be

- [x] Adjusted the popup web view layout params to match the parent view

https://github.com/user-attachments/assets/83dedd8e-da03-467b-9aa8-11caaae49d49

- [x] Set setDomStorageEnabled to true for the popup webview. Unfortunately, I forgot about web development, so I'm unsure why it made a difference.

https://github.com/user-attachments/assets/1f615548-9f37-419c-a5c0-526fc84cea2f

## ☑️ Checklist

- [x] Useless comments and/or `Log.d` etc are **removed**
- [ ] Unit test are **covered**
- [ ] Code has been **deployed and tested** on STG
- [ ] ClickUp ticket status has been **updated** to `production`
- [x] Update CHANGELOG.md with the new changes
