### PR TITLE
Ensure SNS buttons are hidden when configured to do so

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ### Next Release
 - Refactor: merge `virtusize-auth` into the main SDK repository
+- Fix: Ensure SNS buttons are hidden when configured to do so
 
 ### 2.10.0
 - Refactor: Optimize product load time by using async coroutines

--- a/virtusize/src/main/java/com/virtusize/android/ui/VirtusizeWebViewFragment.kt
+++ b/virtusize/src/main/java/com/virtusize/android/ui/VirtusizeWebViewFragment.kt
@@ -117,12 +117,10 @@ class VirtusizeWebViewFragment : DialogFragment() {
                 ) {
                     if (url != null && url.contains(virtusizeWebAppUrl)) {
                         binding.webView.evaluateJavascript(vsParamsFromSDKScript, null)
-                        if (showSNSButtons) {
-                            binding.webView.evaluateJavascript(
-                                "javascript:window.virtusizeSNSEnabled = true;",
-                                null,
-                            )
-                        }
+                        binding.webView.evaluateJavascript(
+                            "javascript:window.virtusizeSNSEnabled = $showSNSButtons;",
+                            null,
+                        )
                         getBrowserIDFromCookies()?.let { bid ->
                             if (bid != sharedPreferencesHelper.getBrowserId()) {
                                 sharedPreferencesHelper.storeBrowserId(bid)


### PR DESCRIPTION
## ⬅️ As Is

- SNS still visible even thought `.setShowSNSButtons(false)` configured

## ➡️ To Be

- [x] Hide SNS buttons when `.setShowSNSButtons(false)` applied

## ☑️ Checklist

- [x] Useless comments and/or `Log.d` etc are **removed**
- [ ] Unit test are **covered**
- [ ] Code has been **deployed and tested** on STG
- [ ] ClickUp ticket status has been **updated** to `production`
- [x] Update CHANGELOG.md with the new changes
