### PR TITLE
Use cache-friendly endpoint to load product types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ### Next Release
 - Refactor: merge `virtusize-auth` into the main SDK repository
+- Fix: use cache-friendly endpoints for faster loading time
 
 ### 2.10.0
 - Refactor: Optimize product load time by using async coroutines

--- a/virtusize-core/src/main/java/com/virtusize/android/network/VirtusizeApi.kt
+++ b/virtusize-core/src/main/java/com/virtusize/android/network/VirtusizeApi.kt
@@ -311,7 +311,7 @@ object VirtusizeApi {
      */
     fun getProductTypes(): ApiRequest {
         val url =
-            Uri.parse(environment.defaultApiUrl() + VirtusizeEndpoint.ProductType.path)
+            Uri.parse(environment.servicesApiUrl() + VirtusizeEndpoint.ProductType.path)
                 .buildUpon()
                 .build()
                 .toString()

--- a/virtusize-core/src/test/java/com/virtusize/android/network/VirtusizeApiTest.kt
+++ b/virtusize-core/src/test/java/com/virtusize/android/network/VirtusizeApiTest.kt
@@ -234,7 +234,7 @@ internal class VirtusizeApiTest {
     fun `test getProductTypes should return expected API request`() {
         val actualApiRequest = VirtusizeApi.getProductTypes()
 
-        val expectedUrl = "https://staging.virtusize.com/a/api/v3/product-types"
+        val expectedUrl = "https://services.virtusize.com/stg/a/api/v3/product-types"
 
         val expectedApiRequest = ApiRequest(expectedUrl, HttpMethod.GET)
 


### PR DESCRIPTION
## ⬅️ As Is

- Product Types always loaded from the origin server, while it's data persistent and could be easily cached

## ➡️ To Be

- [x] Use cache friendly endpoint to load Product Types (as web app does)

## ☑️ Checklist

- [x] Useless comments and/or `Log.d` etc are **removed**
- [x] Unit test are **covered**
- [ ] Code has been **deployed and tested** on STG
- [ ] ClickUp ticket status has been **updated** to `production`
- [x] Update CHANGELOG.md with the new changes
