### PR TITLE
Optimize product loading time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Fix: Use cache-friendly endpoints for faster loading time
 - Fix: Ensure SNS buttons are hidden when configured to do so
 - Fix: Refresh InPage recommendations when measurements changed
+- Refactor: Optimize product loading time for cases when body measurements are not specified
 
 ### 2.10.0
 - Refactor: Optimize product load time by using async coroutines

--- a/virtusize-core/src/main/java/com/virtusize/android/data/parsers/UserSessionInfoJsonParser.kt
+++ b/virtusize-core/src/main/java/com/virtusize/android/data/parsers/UserSessionInfoJsonParser.kt
@@ -7,11 +7,12 @@ import org.json.JSONObject
  * This class parses a JSONObject to the [UserSessionInfo] object
  */
 class UserSessionInfoJsonParser : VirtusizeJsonParser<UserSessionInfo> {
-    override fun parse(json: JSONObject): UserSessionInfo? {
+    override fun parse(json: JSONObject): UserSessionInfo {
         val accessToken = json.optString(FIELD_ID)
         val authToken = json.optString(FIELD_VS_AUTH)
         val bid = json.optJSONObject(FIELD_USER)?.optString(FIELD_BID)
-        return UserSessionInfo(accessToken, bid, authToken, json.toString())
+        val hasBodyMeasurement = json.optJSONObject(FIELD_STATUS)?.optBoolean(FIELD_BODY_MEASUREMENT) ?: false
+        return UserSessionInfo(accessToken, bid, authToken, hasBodyMeasurement, json.toString())
     }
 
     private companion object {
@@ -19,5 +20,7 @@ class UserSessionInfoJsonParser : VirtusizeJsonParser<UserSessionInfo> {
         const val FIELD_VS_AUTH = "x-vs-auth"
         const val FIELD_USER = "user"
         const val FIELD_BID = "bid"
+        const val FIELD_STATUS = "status"
+        const val FIELD_BODY_MEASUREMENT = "hasBodyMeasurement"
     }
 }

--- a/virtusize-core/src/main/java/com/virtusize/android/data/remote/UserSessionInfo.kt
+++ b/virtusize-core/src/main/java/com/virtusize/android/data/remote/UserSessionInfo.kt
@@ -6,10 +6,12 @@ package com.virtusize.android.data.remote
  * @param bid the browser ID
  * @param authToken the auth token
  * @param userSessionResponse the API response as a string
+ * @param hasBodyMeasurement the flag to indicate if a user specified body measurements
  */
 data class UserSessionInfo(
     val accessToken: String,
     internal val bid: String?,
     val authToken: String,
+    val hasBodyMeasurement: Boolean,
     val userSessionResponse: String,
 )

--- a/virtusize-core/src/test/java/com/virtusize/android/network/VirtusizeApiTaskTest.kt
+++ b/virtusize-core/src/test/java/com/virtusize/android/network/VirtusizeApiTaskTest.kt
@@ -211,6 +211,9 @@ internal class VirtusizeApiTaskTest {
                         "firstName":"Anonymous",
                         "language":null
                     },
+                    "status":{
+                        "hasBodyMeasurement":true
+                    },
                     "x-vs-auth":""
                 }
                 """
@@ -229,6 +232,7 @@ internal class VirtusizeApiTaskTest {
                 bid = "test_bid",
                 authToken = "",
                 userSessionResponse = streamString,
+                hasBodyMeasurement = true,
             )
 
         assertThat(returnValue).isEqualTo(expectedUserSessionInfo)


### PR DESCRIPTION
## ⬅️ As Is

- Body measurements are always loaded, even when `user-session` specify there are no measurements yet

## ➡️ To Be

- [x] Load body measurements only if `user-session` defines so

## ☑️ Checklist

- [x] Useless comments and/or `Log.d` etc are **removed**
- [ ] Unit test are **covered**
- [ ] Code has been **deployed and tested** on STG
- [ ] ClickUp ticket status has been **updated** to `production`
- [x] Update CHANGELOG.md with the new changes
