### PR TITLE
Fix release 2.12.0

### DIFF
--- a/README-COMPOSE.md
+++ b/README-COMPOSE.md
@@ -74,7 +74,7 @@ In your app `build.gradle` file, add the following dependencies:
 
   ```groovy
   dependencies {
-    implementation 'com.virtusize.android:virtusize:2.11.1'
+    implementation 'com.virtusize.android:virtusize:2.12.0'
   }
   ```
 
@@ -82,7 +82,7 @@ In your app `build.gradle` file, add the following dependencies:
 
   ```kotlin
   dependencies {
-    implementation("com.virtusize.android:virtusize:2.11.1")
+    implementation("com.virtusize.android:virtusize:2.12.0")
   }
   ```
 

--- a/README-JP.md
+++ b/README-JP.md
@@ -78,7 +78,7 @@ In your appの`build.gradle`ファイルに下記のdependencyを追加
 
   ```groovy
   dependencies {
-    implementation 'com.virtusize.android:virtusize:2.11.1'
+    implementation 'com.virtusize.android:virtusize:2.12.0'
   }
   ```
 
@@ -86,7 +86,7 @@ In your appの`build.gradle`ファイルに下記のdependencyを追加
 
   ```kotlin
   dependencies {
-    implementation("com.virtusize.android:virtusize:2.11.1")
+    implementation("com.virtusize.android:virtusize:2.12.0")
   }
   ```
 

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ In your app `build.gradle` file, add the following dependencies:
 
   ```groovy
   dependencies {
-    implementation 'com.virtusize.android:virtusize:2.11.1'
+    implementation 'com.virtusize.android:virtusize:2.12.0'
   }
   ```
 
@@ -90,7 +90,7 @@ In your app `build.gradle` file, add the following dependencies:
 
   ```kotlin
   dependencies {
-    implementation("com.virtusize.android:virtusize:2.11.1")
+    implementation("com.virtusize.android:virtusize:2.12.0")
   }
   ```
 

--- a/buildSrc/src/main/java/com/virtusize/android/constants/Constants.kt
+++ b/buildSrc/src/main/java/com/virtusize/android/constants/Constants.kt
@@ -6,6 +6,6 @@ object Constants {
     const val TARGET_SDK = 34
 
     // Update versionName when publishing a new release
-    const val VERSION_NAME = "2.11.1"
+    const val VERSION_NAME = "2.12.0"
     const val GROUP_ID = "com.virtusize.android"
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -17,7 +17,7 @@ material = "1.12.0"
 nextPublish = "1.1.0"
 robolectric = "4.13"
 truth = "1.4.4"
-virtusize = "2.11.1"
+virtusize = "2.12.0"
 virtusizeAuth = "1.1.1"
 browser = "1.8.0"
 


### PR DESCRIPTION
## ⬅️ As Is

The version number is still 2.11.1

## ➡️ To Be

- [x] Version umber is 2.12.0

## ☑️ Checklist

- [x] Useless comments and/or `print` etc are **removed**
- [x] Unit test are **covered**
- [ ] Code has been **deployed and tested** on STG
- [ ] ClickUp ticket status has been **updated** to `production`
- [ ] Update CHANGELOG.md with the new changes
