### PR TITLE
Fix shadow clipping in VirtusizeInPageStandard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ### Next Release
 - Feature: Update Flutter SDK implementation to be compatible with latest changes
 - Fix: Replace underscores with hyphens in package name when creating SNS-auth redirect url
+- Fix: Shadow is clipped in compose version of VirtusizeInPageStandard
 
 ### 2.11.1
 - Feature: Allow to specify custom branch for WebView-native apps

--- a/virtusize/src/main/java/com/virtusize/android/compose/ui/VirtusizeInpPageStandard.kt
+++ b/virtusize/src/main/java/com/virtusize/android/compose/ui/VirtusizeInpPageStandard.kt
@@ -3,6 +3,7 @@ package com.virtusize.android.compose.ui
 import android.view.View
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.rememberCoroutineScope
@@ -77,23 +78,26 @@ private fun VirtusizeInPageStandard(
         factory = { context ->
             VirtusizeInPageStandard(context).apply {
                 horizontalMargin = 0
+                clipChildren = false
             }
         },
         update = update,
     )
 }
 
-@Preview
+@Preview(showBackground = true)
 @Composable
 private fun VirtusizeInPageStandardPreview() {
     Column(verticalArrangement = Arrangement.spacedBy(16.dp)) {
         VirtusizeInPageStandard(
+            modifier = Modifier.padding(16.dp),
             update = { virtusizeInPageStandard ->
                 virtusizeInPageStandard.visibility = View.VISIBLE
                 virtusizeInPageStandard.virtusizeViewStyle = VirtusizeViewStyle.TEAL
             },
         )
         VirtusizeInPageStandard(
+            modifier = Modifier.padding(16.dp),
             update = { virtusizeInPageStandard ->
                 virtusizeInPageStandard.visibility = View.VISIBLE
                 virtusizeInPageStandard.virtusizeViewStyle = VirtusizeViewStyle.BLACK


### PR DESCRIPTION
Fix shadow clipping in compose version of VirtusizeInPageStandard; 
Update preview of VirtusizeInPageStandatd to better reflect the changes;

## ⬅️ As Is

![sample before](https://github.com/user-attachments/assets/78c218de-020d-4830-b2bc-ab9820e37c2d)
<img width="338" alt="preview before" src="https://github.com/user-attachments/assets/4953d68e-8c0e-4dd3-b95d-50093dbcf90a" />


## ➡️ To Be

![sample after](https://github.com/user-attachments/assets/93e1d2a9-da7c-4d70-a4f4-2d4a41697434)
<img width="339" alt="preview after" src="https://github.com/user-attachments/assets/4f8589e3-cf95-4fc4-9250-2291985b5cd3" />


## ☑️ Checklist

- [ ] Useless comments and/or `Log.d` etc are **removed**
- [ ] Unit test are **covered**
- [ ] Code has been **deployed and tested** on STG
- [ ] ClickUp ticket status has been **updated** to `production`
- [x] Update CHANGELOG.md with the new changes
