### PR TITLE
Fix memory leak in VirtusizeImpl.virtusizeViews

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ### Next Release
 - Feature: Update Flutter SDK implementation to be compatible with latest changes
 - Fix: Replace underscores with hyphens in package name when creating SNS-auth redirect url
+- Fix: memory leak with Virtusize composables
 
 ### 2.11.1
 - Feature: Allow to specify custom branch for WebView-native apps

--- a/virtusize/src/main/java/com/virtusize/android/Virtusize.kt
+++ b/virtusize/src/main/java/com/virtusize/android/Virtusize.kt
@@ -45,12 +45,16 @@ interface Virtusize {
          * @throws IllegalStateException if the [Virtusize] instance is not initialized
          */
         @Throws(IllegalStateException::class)
-        fun getInstance(): Virtusize =
-            if (!Companion::instance.isInitialized) {
-                throw IllegalStateException("Virtusize is not initialized")
-            } else {
-                instance
-            }
+        fun getInstance(): Virtusize = getInstanceOrNull() ?: throw IllegalStateException("Virtusize is not initialized")
+
+        /**
+         * Get the [Virtusize] instance or return `null`, if [Virtusize] has not been yet initialized
+         */
+        fun getInstanceOrNull(): Virtusize? = if (!Companion::instance.isInitialized) {
+            null
+        } else {
+            instance
+        }
     }
 
     /**
@@ -117,6 +121,13 @@ interface Virtusize {
     fun setupVirtusizeView(
         virtusizeView: VirtusizeView?,
         product: VirtusizeProduct,
+    )
+
+    /**
+     * Cleanup [virtusizeView] once it's no longer needed (e.g. leaves the composition)
+     */
+    fun cleanupVirtusizeView(
+        virtusizeView: VirtusizeView,
     )
 
     /**

--- a/virtusize/src/main/java/com/virtusize/android/VirtusizeImpl.kt
+++ b/virtusize/src/main/java/com/virtusize/android/VirtusizeImpl.kt
@@ -354,6 +354,10 @@ internal class VirtusizeImpl(
         virtusizeViews.add(virtusizeView)
     }
 
+    override fun cleanupVirtusizeView(virtusizeView: VirtusizeView) {
+        virtusizeViews.remove(virtusizeView)
+    }
+
     /**
      * @see Virtusize.sendOrder
      */

--- a/virtusize/src/main/java/com/virtusize/android/compose/ui/VirtusizeButton.kt
+++ b/virtusize/src/main/java/com/virtusize/android/compose/ui/VirtusizeButton.kt
@@ -21,6 +21,7 @@ import androidx.compose.ui.viewinterop.AndroidView
 import androidx.compose.ui.viewinterop.NoOpUpdate
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.virtusize.android.R
+import com.virtusize.android.Virtusize
 import com.virtusize.android.compose.theme.VirtusizeColors
 import com.virtusize.android.data.local.VirtusizeError
 import com.virtusize.android.data.local.VirtusizeEvent
@@ -92,6 +93,9 @@ private fun VirtusizeButton(
         update = { virtusizeButton ->
             virtusizeButton.virtusizeViewStyle = style
             update(virtusizeButton)
+        },
+        onRelease = { virtusizeView ->
+            Virtusize.getInstanceOrNull()?.cleanupVirtusizeView(virtusizeView)
         },
     )
 }

--- a/virtusize/src/main/java/com/virtusize/android/compose/ui/VirtusizeInPageMini.kt
+++ b/virtusize/src/main/java/com/virtusize/android/compose/ui/VirtusizeInPageMini.kt
@@ -14,6 +14,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.viewinterop.AndroidView
 import androidx.compose.ui.viewinterop.NoOpUpdate
 import androidx.lifecycle.viewmodel.compose.viewModel
+import com.virtusize.android.Virtusize
 import com.virtusize.android.compose.theme.VirtusizeColors
 import com.virtusize.android.data.local.VirtusizeError
 import com.virtusize.android.data.local.VirtusizeEvent
@@ -75,6 +76,9 @@ private fun VirtusizeInPageMini(
         modifier = modifier,
         factory = { context -> VirtusizeInPageMini(context) },
         update = update,
+        onRelease = { virtusizeView ->
+            Virtusize.getInstanceOrNull()?.cleanupVirtusizeView(virtusizeView)
+        },
     )
 }
 

--- a/virtusize/src/main/java/com/virtusize/android/compose/ui/VirtusizeInpPageStandard.kt
+++ b/virtusize/src/main/java/com/virtusize/android/compose/ui/VirtusizeInpPageStandard.kt
@@ -14,6 +14,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.viewinterop.AndroidView
 import androidx.compose.ui.viewinterop.NoOpUpdate
 import androidx.lifecycle.viewmodel.compose.viewModel
+import com.virtusize.android.Virtusize
 import com.virtusize.android.compose.theme.VirtusizeColors
 import com.virtusize.android.data.local.VirtusizeError
 import com.virtusize.android.data.local.VirtusizeEvent
@@ -80,6 +81,9 @@ private fun VirtusizeInPageStandard(
             }
         },
         update = update,
+        onRelease = { virtusizeView ->
+            Virtusize.getInstanceOrNull()?.cleanupVirtusizeView(virtusizeView)
+        },
     )
 }
 


### PR DESCRIPTION
Fix memory leak in `VirtusizeImpl.virtusizeViews`;
Add `Virtusize.getInstanceOrNull()` to better support lazy scenarios;

## ⬅️ As Is

When using Virtusize composables, underlying `VirtusizeView`s (which are regular Android views) insances are stored in the `VirtusizeImpl` singleton in `virtusizeViews` and are never released, causing them to leak

## ➡️ To Be

`VirtusizeView` isntances are removed form the singleton after Virtusize composables leave the composition, allowing them to be garbage collected.

## ☑️ Checklist

- [ ] Useless comments and/or `Log.d` etc are **removed**
- [ ] Unit test are **covered**
- [ ] Code has been **deployed and tested** on STG
- [ ] ClickUp ticket status has been **updated** to `production`
- [x] Update CHANGELOG.md with the new changes
