### PR TITLE
Align Virtusize button texts with Aoyama

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@
 - Fix: Replace LifecycleOwner with ViewTreeLifecycleOwner in VirtusizeInPageStandart to prevent an infinite loading in fragments
 - Fix: Add prefix 'virtusize_' to all drawables' names to prevent conflicts with client's resources
 - Fix: Fix user auth data storing
-= Fix: Add loading animation for VirtusizeInPageViews
+- Fix: Add loading animation for VirtusizeInPageViews
+- Fix: Change inpage buttons text to be the same as in web version
 
 ### 2.12.0
 - Feature: Update Flutter SDK implementation to be compatible with latest changes

--- a/virtusize/src/main/res/values-ja/strings.xml
+++ b/virtusize/src/main/res/values-ja/strings.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="virtusize_name">バーチャサイズ</string>
-    <string name="virtusize_button_text">サイズチェック</string>
+    <string name="virtusize_button_text">試着する</string>
     <string name="virtusize_privacy_policy">プライバシーポリシー</string>
     <string name="virtusize_privacy_policy_link">https://www.virtusize.jp/privacy-policy</string>
     <string name="inpage_loading_text">サイズを分析中</string>

--- a/virtusize/src/main/res/values-ko/strings.xml
+++ b/virtusize/src/main/res/values-ko/strings.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="virtusize_name">버츄사이즈</string>
-    <string name="virtusize_button_text">사이즈 확인</string>
+    <string name="virtusize_button_text">입어보기</string>
     <string name="virtusize_privacy_policy">개인정보 처리방침</string>
     <string name="virtusize_privacy_policy_link">https://www.virtusize.kr/privacy-policy</string>
     <string name="inpage_loading_text">사이즈 분석 중</string>

--- a/virtusize/src/main/res/values/strings.xml
+++ b/virtusize/src/main/res/values/strings.xml
@@ -2,7 +2,7 @@
     <string name="virtusize_name">Virtusize</string>
     <string name="landscape" translatable="false">landscape</string>
     <string name="portrait" translatable="false">portrait</string>
-    <string name="virtusize_button_text">Check size</string>
+    <string name="virtusize_button_text">Try it on</string>
     <string name="virtusize_privacy_policy">Privacy Policy</string>
     <string name="virtusize_privacy_policy_link">https://www.virtusize.com/site/privacy-policy</string>
     <string name="inpage_loading_text">Analyzing the size</string>


### PR DESCRIPTION
## 🔗 Related Links

- [x] [ClickUp](https://app.clickup.com/t/3702259/NSDK-289)

## ⬅️ As Is

Virtusize SDK's inpage buttons text is not the same as in web version.

## ➡️ To Be

- [x] Virtusize SDK's inpage buttons text is the same as in web version.

## ☑️ Checklist

- [x] Useless comments and/or `print` etc are **removed**
- [x] Unit test are **covered**
- [ ] Code has been **deployed and tested** on STG
- [ ] ClickUp ticket status has been **updated** to `production`
- [x] Update CHANGELOG.md with the new changes
