### PR TITLE
Make sns buttons shown by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@
 - Fix: Replace LifecycleOwner with ViewTreeLifecycleOwner in VirtusizeInPageStandart to prevent an infinite loading in fragments
 - Fix: Add prefix 'virtusize_' to all drawables' names to prevent conflicts with client's resources
 - Fix: Fix user auth data storing
-= Fix: Add loading animation for VirtusizeInPageViews
+- Fix: Add loading animation for VirtusizeInPageViews
+- Fix: Make sns buttons shown by default
 
 ### 2.12.0
 - Feature: Update Flutter SDK implementation to be compatible with latest changes

--- a/README-COMPOSE.md
+++ b/README-COMPOSE.md
@@ -114,7 +114,7 @@ following table:
 | setShowSGI           | Boolean                           | setShowSGI(true)                                                                                                                                                                                                                               | Determines whether the integration will fetch SGI and use SGI flow for users to add user generated items to their wardrobe.                                                                                                                       | No. By default, ShowSGI is set to false                                                                                |
 | setAllowedLanguages  | A list of `VirtusizeLanguage`     | In Kotlin, setAllowedLanguages(mutableListOf(VirtusizeLanguage.EN, VirtusizeLanguage.JP))<br />In Java, setAllowedLanguages(Arrays.asList(VirtusizeLanguage.EN, VirtusizeLanguage.JP))                                                         | The languages which the user can switch to using the Language Selector                                                                                                                                                                            | No. By default, the integration allows all possible languages to be displayed, including English, Japanese and Korean. |
 | setDetailsPanelCards | A list of `VirtusizeInfoCategory` | In Kotlin, setDetailsPanelCards(mutableListOf(VirtusizeInfoCategory.BRAND_SIZING, VirtusizeInfoCategory.GENERAL_FIT))<br />In Java, setDetailsPanelCards(Arrays.asList(VirtusizeInfoCategory.BRAND_SIZING, VirtusizeInfoCategory.GENERAL_FIT)) | The info categories which will be display in the Product Details tab. Possible categories are: `VirtusizeInfoCategory.MODEL_INFO`, `VirtusizeInfoCategory.GENERAL_FIT`, `VirtusizeInfoCategory.BRAND_SIZING` and `VirtusizeInfoCategory.MATERIAL` | No. By default, the integration displays all the possible info categories in the Product Details tab.                  |
-| setShowSNSButtons | Boolean | setShowSNSButtons(true) | Determines whether the integration will show the SNS buttons to the users | No. By default, the integration disables the SNS buttons |
+| setShowSNSButtons | Boolean | setShowSNSButtons(true) | Determines whether the integration will show the SNS buttons to the users | No. By default, the integration enables the SNS buttons |
 
 ```kotlin
 override fun onCreate() {
@@ -136,8 +136,8 @@ override fun onCreate() {
   .setAllowedLanguages(listOf(VirtusizeLanguage.EN, VirtusizeLanguage.JP))
   // By default, Virtusize displays all the possible info categories in the Product Details tab
   .setDetailsPanelCards(setOf(VirtusizeInfoCategory.BRAND_SIZING, VirtusizeInfoCategory.GENERAL_FIT))
-  // By default, Virtusize disables the SNS buttons
-  .setShowSNSButtons(false)
+  // By default, Virtusize enables the SNS buttons
+  .setShowSNSButtons(true)
   .build()
 }
 ```

--- a/README-JP.md
+++ b/README-JP.md
@@ -113,7 +113,7 @@ Proguardをお使いの場合、Proguardのルールファイルに下記のル�
 | setShowSGI           | Boolean                       | setShowSGI(true)                                                                                                                                                                                                                               | ユーザーが生成したアイテムをワードローブに追加するために、SGIを取得してSGIフローを使用するかどうかを決定します。                                                                                                                    | 特になし。デフォルトではShowSGIはfalseに設定されています。                   |
 | setAllowedLanguages  | `VirtusizeLanguage`列挙のリスト     | In Kotlin, setAllowedLanguages(mutableListOf(VirtusizeLanguage.EN, VirtusizeLanguage.JP))<br />In Java, setAllowedLanguages(Arrays.asList(VirtusizeLanguage.EN, VirtusizeLanguage.JP))                                                         | ユーザーが言語選択ボタンより選択できる言語                                                                                                                                                          | 特になし。デフォルトでは、英語、日本語、韓国語など、表示可能なすべての言語が表示されるようになっています。 |
 | setDetailsPanelCards | `VirtusizeInfoCategory`列挙のリスト | In Kotlin, setDetailsPanelCards(mutableListOf(VirtusizeInfoCategory.BRAND_SIZING, VirtusizeInfoCategory.GENERAL_FIT))<br />In Java, setDetailsPanelCards(Arrays.asList(VirtusizeInfoCategory.BRAND_SIZING, VirtusizeInfoCategory.GENERAL_FIT)) | 商品詳細タブに表示する情報のカテゴリ。表示可能カテゴリは以下：`VirtusizeInfoCategory.MODELINFO`, `VirtusizeInfoCategory.GENERALFIT`, `VirtusizeInfoCategory.BRANDSIZING` および `VirtusizeInfoCategory.MATERIAL` | 特になし。デフォルトでは、商品詳細タブに表示可能なすべての情報カテゴリが表示されます。           |
-| setShowSNSButtons | Boolean | setShowSNSButtons(true) | Determines whether the integration will show the SNS buttons to the users | No. By default, the integration disables the SNS buttons |
+| setShowSNSButtons | Boolean | setShowSNSButtons(true) | Determines whether the integration will show the SNS buttons to the users | No. By default, the integration enables the SNS buttons |
 
 ```kotlin
 override fun onCreate() {
@@ -135,8 +135,8 @@ override fun onCreate() {
   .setAllowedLanguages(listOf(VirtusizeLanguage.EN, VirtusizeLanguage.JP))
   // デフォルトでは、商品詳細タブにすべての情報カテゴリが表示される
   .setDetailsPanelCards(setOf(VirtusizeInfoCategory.BRAND_SIZING, VirtusizeInfoCategory.GENERAL_FIT))
-  // デフォルトでは、SNS ボタンは非表示
-  .setShowSNSButtons(false)
+  // デフォルトでは、SNS ボタンが表示されます
+  .setShowSNSButtons(true)
   .build()
 }
 ```

--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ following table:
 | setShowSGI           | Boolean                           | setShowSGI(true)                                                                                                                                                                                                                               | Determines whether the integration will fetch SGI and use SGI flow for users to add user generated items to their wardrobe.                                                                                                                       | No. By default, ShowSGI is set to false                                                                                |
 | setAllowedLanguages  | A list of `VirtusizeLanguage`     | In Kotlin, setAllowedLanguages(mutableListOf(VirtusizeLanguage.EN, VirtusizeLanguage.JP))<br />In Java, setAllowedLanguages(Arrays.asList(VirtusizeLanguage.EN, VirtusizeLanguage.JP))                                                         | The languages which the user can switch to using the Language Selector                                                                                                                                                                            | No. By default, the integration allows all possible languages to be displayed, including English, Japanese and Korean. |
 | setDetailsPanelCards | A list of `VirtusizeInfoCategory` | In Kotlin, setDetailsPanelCards(mutableListOf(VirtusizeInfoCategory.BRAND_SIZING, VirtusizeInfoCategory.GENERAL_FIT))<br />In Java, setDetailsPanelCards(Arrays.asList(VirtusizeInfoCategory.BRAND_SIZING, VirtusizeInfoCategory.GENERAL_FIT)) | The info categories which will be display in the Product Details tab. Possible categories are: `VirtusizeInfoCategory.MODEL_INFO`, `VirtusizeInfoCategory.GENERAL_FIT`, `VirtusizeInfoCategory.BRAND_SIZING` and `VirtusizeInfoCategory.MATERIAL` | No. By default, the integration displays all the possible info categories in the Product Details tab.                  |
-| setShowSNSButtons    | Boolean                           | setShowSNSButtons(true)                                                                                                                                                                                                                        | Determines whether the integration will show the SNS buttons to the users                                                                                                                                                                         | No. By default, the integration disables the SNS buttons                                                               |
+| setShowSNSButtons    | Boolean                           | setShowSNSButtons(true)                                                                                                                                                                                                                        | Determines whether the integration will show the SNS buttons to the users                                                                                                                                                                         | No. By default, the integration enables the SNS buttons                                                               |
 | setBranch     | String                            | setBranch("branch-name")                                                                                                                                                                                                                | Targets specific environment branch                                                                                                                                                                                         | No. By default, production environment is targeted. `staging` targets staging environment. `<branch-name>` targets a specific branch                                                                     |
 
 - Kotlin
@@ -146,7 +146,7 @@ following table:
       .setAllowedLanguages(listOf(VirtusizeLanguage.EN, VirtusizeLanguage.JP))
       // By default, Virtusize displays all the possible info categories in the Product Details tab
       .setDetailsPanelCards(setOf(VirtusizeInfoCategory.BRAND_SIZING, VirtusizeInfoCategory.GENERAL_FIT))
-      // By default, Virtusize disables the SNS buttons
+      // By default, Virtusize enables the SNS buttons
       .setShowSNSButtons(false)
       // Target the specific branch environment by its name
       .setBranch("branch-name")  
@@ -179,7 +179,7 @@ following table:
         .setAllowedLanguages(Arrays.asList(VirtusizeLanguage.EN, VirtusizeLanguage.JP))
         // By default, Virtusize displays all the possible info categories in the Product Details tab
         .setDetailsPanelCards(Set.of(VirtusizeInfoCategory.BRAND_SIZING, VirtusizeInfoCategory.GENERAL_FIT))
-        // By default, Virtusize disables the SNS buttons
+        // By default, Virtusize enables the SNS buttons
         .setShowSNSButtons(false)
         // Target the specific environment branch by its name
         .setBranch("branch-name")    

--- a/sampleAppKotlin/src/main/java/com/virtusize/sampleappkotlin/App.kt
+++ b/sampleAppKotlin/src/main/java/com/virtusize/sampleappkotlin/App.kt
@@ -26,7 +26,7 @@ class App : Application() {
             .setAllowedLanguages(listOf(VirtusizeLanguage.EN, VirtusizeLanguage.JP))
             // By default, Virtusize displays all the possible info categories in the Product Details tab
             .setDetailsPanelCards(setOf(VirtusizeInfoCategory.BRAND_SIZING, VirtusizeInfoCategory.GENERAL_FIT))
-            // By default, Virtusize disables the SNS buttons
+            // By default, Virtusize enables the SNS buttons
             .setShowSNSButtons(true)
             // By default, branch is empty and `production` is used
             // .setBranch("branch-name")

--- a/sampleappcompose/src/main/java/com/virtusize/sampleapp/compose/VirtusizeSampleApplication.kt
+++ b/sampleappcompose/src/main/java/com/virtusize/sampleapp/compose/VirtusizeSampleApplication.kt
@@ -25,7 +25,7 @@ internal class VirtusizeSampleApplication : Application() {
             .setAllowedLanguages(listOf(VirtusizeLanguage.EN, VirtusizeLanguage.JP))
             // By default, Virtusize displays all the possible info categories in the Product Details tab
             .setDetailsPanelCards(setOf(VirtusizeInfoCategory.BRAND_SIZING, VirtusizeInfoCategory.GENERAL_FIT))
-            // By default, Virtusize disables the SNS buttons
+            // By default, Virtusize enables the SNS buttons
             .setShowSNSButtons(false)
             .build()
     }

--- a/sampleappjava/src/main/java/com/virtusize/sampleappjava/App.java
+++ b/sampleappjava/src/main/java/com/virtusize/sampleappjava/App.java
@@ -35,7 +35,7 @@ public class App extends Application {
                 .setAllowedLanguages(Arrays.asList(VirtusizeLanguage.EN, VirtusizeLanguage.JP))
                 // By default, Virtusize displays all the possible info categories in the Product Details tab
                 .setDetailsPanelCards(Set.of(VirtusizeInfoCategory.BRAND_SIZING, VirtusizeInfoCategory.GENERAL_FIT))
-                // By default, Virtusize disables the SNS buttons
+                // By default, Virtusize enables the SNS buttons
                 .setShowSNSButtons(false)
                 .build();
     }

--- a/virtusize/src/main/java/com/virtusize/android/VirtusizeBuilder.kt
+++ b/virtusize/src/main/java/com/virtusize/android/VirtusizeBuilder.kt
@@ -35,7 +35,7 @@ class VirtusizeBuilder {
         VirtusizeLanguage.entries.toMutableList()
     private var showSGI: Boolean = false
     private var detailsPanelCards: Set<VirtusizeInfoCategory> = VirtusizeInfoCategory.entries.toMutableSet()
-    private var showSNSButtons: Boolean = false
+    private var showSNSButtons: Boolean = true
     private var branch: String? = null
 
     /**
@@ -128,7 +128,7 @@ class VirtusizeBuilder {
 
     /**
      * Sets up whether the Virtusize web app will show the SNS buttons
-     * By default, showSNSButtons is false
+     * By default, showSNSButtons is true
      * @param showSNSButtons the Boolean value
      * @return [VirtusizeBuilder]
      */

--- a/virtusize/src/main/java/com/virtusize/android/flutter/VirtusizeFlutterBuilder.kt
+++ b/virtusize/src/main/java/com/virtusize/android/flutter/VirtusizeFlutterBuilder.kt
@@ -35,7 +35,7 @@ class VirtusizeFlutterBuilder {
         VirtusizeLanguage.entries.toMutableList()
     private var showSGI: Boolean = false
     private var detailsPanelCards: Set<VirtusizeInfoCategory> = VirtusizeInfoCategory.entries.toMutableSet()
-    private var showSNSButtons: Boolean = false
+    private var showSNSButtons: Boolean = true
     private var branch: String? = null
     private var virtusizeFlutterPresenter: VirtusizeFlutterPresenter? = null
 
@@ -129,7 +129,7 @@ class VirtusizeFlutterBuilder {
 
     /**
      * Sets up whether the Virtusize web app will show the SNS buttons
-     * By default, showSNSButtons is false
+     * By default, showSNSButtons is true
      * @param showSNSButtons the Boolean value
      * @return [VirtusizeFlutterBuilder]
      */

--- a/virtusize/src/main/java/com/virtusize/android/ui/VirtusizeWebViewFragment.kt
+++ b/virtusize/src/main/java/com/virtusize/android/ui/VirtusizeWebViewFragment.kt
@@ -43,7 +43,7 @@ import org.json.JSONObject
 class VirtusizeWebViewFragment : DialogFragment() {
     private var virtusizeWebAppUrl: String = VirtusizeApi.getVirtusizeWebViewURL()
 
-    private var showSNSButtons: Boolean = false
+    private var showSNSButtons: Boolean = true
     private var vsParamsFromSDKScript = ""
     private var backButtonClickEventFromSDKScript =
         "javascript:vsEventFromSDK({ name: 'sdk-back-button-tapped'})"


### PR DESCRIPTION
## 🔗 Related Links

- [x] [ClickUp](https://app.clickup.com/t/3702259/NSDK-290)

## ⬅️ As Is

Sns buttons are hidden by default and should be enabled by setting showSNSButtons: true in VirtusizeParamsBuilder.

## ➡️ To Be

- [x] Sns buttons are enabled by default

## ☑️ Checklist

- [x] Useless comments and/or `print` etc are **removed**
- [x] Unit test are **covered**
- [ ] Code has been **deployed and tested** on STG
- [ ] ClickUp ticket status has been **updated** to `production`
- [x] Update CHANGELOG.md with the new changes
