### PR TITLE
Update sonatype urls

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -22,8 +22,8 @@ nexusPublishing {
     repositories {
         sonatype {
             // only for users registered in Sonatype after 24 Feb 2021
-            nexusUrl.set(uri("https://s01.oss.sonatype.org/service/local/"))
-            snapshotRepositoryUrl.set(uri("https://s01.oss.sonatype.org/content/repositories/snapshots/"))
+            nexusUrl.set(uri("https://ossrh-staging-api.central.sonatype.com/service/local/"))
+            snapshotRepositoryUrl.set(uri("https://central.sonatype.com/repository/maven-snapshots/"))
             username = getProperties("OSSRH_USERNAME")
             password = getProperties("OSSRH_PASSWORD")
         }

--- a/buildSrc/src/main/java/com/virtusize/android/extensions/Publications.kt
+++ b/buildSrc/src/main/java/com/virtusize/android/extensions/Publications.kt
@@ -17,10 +17,11 @@ private fun Project.configureRepositories() {
         publications {
             repositories {
                 maven {
+                    name = "ossrh-staging-api"
                     val releasesRepoUrl =
-                        "https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/"
+                        "https://ossrh-staging-api.central.sonatype.com/service/local/staging/deploy/maven2/"
                     val snapshotsRepoUrl =
-                        "https://s01.oss.sonatype.org/content/repositories/snapshots/"
+                        "https://central.sonatype.com/repository/maven-snapshots/"
                     url =
                         uri(if (isSnapshot) snapshotsRepoUrl else releasesRepoUrl)
                     credentials {


### PR DESCRIPTION
## ⬅️ As Is

The Sonatype support ended so the publishing to Maven was failing.

## ➡️ To Be

- [x] Publishing to Maven works again.

## ☑️ Checklist

- [x] Useless comments and/or `Log.d` etc are **removed**
- [x] Unit test are **covered**
- [ ] Code has been **deployed and tested** on STG
- [ ] ClickUp ticket status has been **updated** to `production`
- [ ] Update CHANGELOG.md with the new changes
