### PR TITLE
Add Android 15+ support memory page size of 16KB

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
-### Next release
-- Feature: Update Flutter SDK implementation to be compatible with latest changes
-
 ### 2.12.6
 - Feature: Add Android 15+ support a memory page size of 16KB.
+
+### 2.12.5
+- Feature: Update Flutter SDK implementation to be compatible with latest changes
 
 ### 2.12.4
 - Feature: Add event listener to handle language change on web in Virtusize widgets

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 ### Next release
 - Feature: Update Flutter SDK implementation to be compatible with latest changes
 
+### 2.12.6
+- Feature: Add Android 15+ support a memory page size of 16KB.
+
 ### 2.12.4
 - Feature: Add event listener to handle language change on web in Virtusize widgets
 

--- a/README-COMPOSE.md
+++ b/README-COMPOSE.md
@@ -74,7 +74,7 @@ In your app `build.gradle` file, add the following dependencies:
 
   ```groovy
   dependencies {
-    implementation 'com.virtusize.android:virtusize:2.12.4'
+    implementation 'com.virtusize.android:virtusize:2.12.6'
   }
   ```
 
@@ -82,7 +82,7 @@ In your app `build.gradle` file, add the following dependencies:
 
   ```kotlin
   dependencies {
-    implementation("com.virtusize.android:virtusize:2.12.4")
+    implementation("com.virtusize.android:virtusize:2.12.6")
   }
   ```
 

--- a/README-JP.md
+++ b/README-JP.md
@@ -75,7 +75,7 @@ appの`build.gradle`ファイルに下記のdependencyを追加
 
   ```groovy
   dependencies {
-    implementation 'com.virtusize.android:virtusize:2.12.4'
+    implementation 'com.virtusize.android:virtusize:2.12.6'
   }
   ```
 
@@ -83,7 +83,7 @@ appの`build.gradle`ファイルに下記のdependencyを追加
 
   ```kotlin
   dependencies {
-    implementation("com.virtusize.android:virtusize:2.12.4")
+    implementation("com.virtusize.android:virtusize:2.12.6")
   }
   ```
 

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ In your app `build.gradle` file, add the following dependencies:
 
   ```groovy
   dependencies {
-    implementation 'com.virtusize.android:virtusize:2.12.4'
+    implementation 'com.virtusize.android:virtusize:2.12.6'
   }
   ```
 
@@ -90,7 +90,7 @@ In your app `build.gradle` file, add the following dependencies:
 
   ```kotlin
   dependencies {
-    implementation("com.virtusize.android:virtusize:2.12.4")
+    implementation("com.virtusize.android:virtusize:2.12.6")
   }
   ```
 

--- a/buildSrc/src/main/java/com/virtusize/android/constants/Constants.kt
+++ b/buildSrc/src/main/java/com/virtusize/android/constants/Constants.kt
@@ -3,9 +3,9 @@ package com.virtusize.android.constants
 object Constants {
     const val COMPILE_SDK = 34
     const val MIN_SDK = 21
-    const val TARGET_SDK = 34
+    const val TARGET_SDK = 35
 
     // Update versionName when publishing a new release
-    const val VERSION_NAME = "2.12.4"
+    const val VERSION_NAME = "2.12.6"
     const val GROUP_ID = "com.virtusize.android"
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -21,3 +21,7 @@ kotlin.code.style=official
 # resources declared in the library itself and none from the library's dependencies,
 # thereby reducing the size of the R class for that library
 android.nonTransitiveRClass=true
+
+# Enable 16KB page size support for Android 15+
+# This ensures compatibility with devices using 16KB page sizes
+android.experimental.enableKmp16KbPageSizeWarning=true

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -20,7 +20,7 @@ material = "1.12.0"
 nextPublish = "1.1.0"
 robolectric = "4.13"
 truth = "1.4.4"
-virtusize = "2.12.4"
+virtusize = "2.12.6"
 virtusizeAuth = "1.1.1"
 browser = "1.8.0"
 


### PR DESCRIPTION
## 🔗 Related Links

- [ ] [ClickUp](https://app.clickup.com/t/3702259/NSDK-302)

## ⬅️ As Is

According to Google Play’s review requirements, all apps targeting Android 15 and above are required to support a memory page size of 16KB.

## ➡️ To Be

Added Android 15+ support memory page size of 16KB

## ☑️ Checklist

- [ ] Useless comments and/or `Log.d` etc are **removed**
- [ ] Unit test are **covered**
- [ ] Code has been **deployed and tested** on STG
- [ ] ClickUp ticket status has been **updated** to `production`
- [ ] Update CHANGELOG.md with the new changes
