### PR TITLE
NSDK-400 - Compose UI Components Not Reloading After Environment Change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+### Changes
+- Fix: Compose UI components reload event changes
+
 ### 2.12.18
 - Fix: Added configurable ApiKey and Environment parameters
 - 

--- a/virtusize/src/main/java/com/virtusize/android/compose/ui/VirtusizeComposeViewModel.kt
+++ b/virtusize/src/main/java/com/virtusize/android/compose/ui/VirtusizeComposeViewModel.kt
@@ -60,12 +60,17 @@ internal class VirtusizeComposeViewModel : ViewModel() {
         virtusize.registerMessageHandler(messageHandler)
     }
 
+    private var lastLoadedProductId: String? = null
+
     fun load(
         product: VirtusizeProduct,
         virtusizeView: VirtusizeView,
     ) {
-        virtusize.load(product)
         virtusize.setupVirtusizeView(product = product, virtusizeView = virtusizeView)
+        if (lastLoadedProductId != product.externalId) {
+            lastLoadedProductId = product.externalId
+            virtusize.load(product)
+        }
     }
 
     override fun onCleared() {

--- a/virtusize/src/main/java/com/virtusize/android/compose/ui/VirtusizeInpPageStandard.kt
+++ b/virtusize/src/main/java/com/virtusize/android/compose/ui/VirtusizeInpPageStandard.kt
@@ -70,7 +70,6 @@ fun VirtusizeInPageStandard(
     }
 }
 
-
 @Composable
 private fun VirtusizeInPageStandard(
     modifier: Modifier = Modifier,


### PR DESCRIPTION
## 🔗 Related Links

- [ ] [ClickUp](https://app.clickup.com/t/3702259/NSDK-400)

## ⬅️ As Is

There is a bug when switching between countries. After updating the API key and environment for the newly selected country, the recommended size value does not refresh and continues to show data from the previous country.

## ➡️ To Be

When the country is changed and the API key and environment are updated, the UI should trigger a reload of the relevant components so that the recommended size is recalculated and displayed correctly for the selected country.

## ☑️ Checklist

- [ ] Useless comments and/or `Log.d` etc are **removed**
- [ ] Unit test are **covered**
- [ ] Code has been **deployed and tested** on STG
- [ ] ClickUp ticket status has been **updated** to `production`
- [ ] Update CHANGELOG.md with the new changes
