### PR TITLE
NSDK-293 fix request 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+### Changes:
+- Fix: Compose VirtusizeInPageMini VirtusizeInPageStandard update fix
+
 ### 2.12.20
 - Fix: Prevent send event userSawProduct when productValid = false or repeated product load
 

--- a/sampleappcompose/src/main/java/com/virtusize/sampleapp/compose/VirtusizeSampleApp.kt
+++ b/sampleappcompose/src/main/java/com/virtusize/sampleapp/compose/VirtusizeSampleApp.kt
@@ -7,11 +7,15 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Button
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.key
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
@@ -43,45 +47,55 @@ internal fun VirtusizeSampleApp() {
                 )
             }
 
-            VirtusizeButton(
-                product = product,
-                modifier = Modifier.align(Alignment.CenterHorizontally),
-                colors =
-                    VirtusizeButtonDefaults.colors(
-                        containerColor = VirtusizeColors.Teal,
-                        contentColor = VirtusizeColors.White,
-                    ),
-                onEvent = { event ->
-                    Log.i(VIRTUSIZE_BUTTON_TAG, event.name)
-                },
-                onError = { error ->
-                    Log.e(VIRTUSIZE_BUTTON_TAG, error.message)
-                },
-            )
-            Spacer(modifier = Modifier.height(16.dp))
-            VirtusizeInPageStandard(
-                product = product,
-                modifier = Modifier.padding(horizontal = 16.dp),
-                backgroundColor = VirtusizeColors.Black,
-                onEvent = { event ->
-                    Log.i(VIRTUSIZE_INPAGE_STANDARD_TAG, event.name)
-                },
-                onError = { error ->
-                    Log.e(VIRTUSIZE_INPAGE_STANDARD_TAG, error.message)
-                },
-            )
-            Spacer(modifier = Modifier.height(16.dp))
-            VirtusizeInPageMini(
-                product = product,
-                modifier = Modifier.padding(horizontal = 16.dp),
-                backgroundColor = VirtusizeColors.Teal,
-                onEvent = { event ->
-                    Log.i(VIRTUSIZE_INPAGE_MINI_TAG, event.name)
-                },
-                onError = { error ->
-                    Log.e(VIRTUSIZE_INPAGE_MINI_TAG, error.message)
-                },
-            )
+            var someKey by remember { mutableStateOf(true) }
+            Button({ someKey = !someKey }) {
+                Text("Reenter composition")
+            }
+
+            key(someKey) {
+                VirtusizeButton(
+                    product = product,
+                    modifier = Modifier.align(Alignment.CenterHorizontally),
+                    colors =
+                        VirtusizeButtonDefaults.colors(
+                            containerColor = VirtusizeColors.Teal,
+                            contentColor = VirtusizeColors.White,
+                        ),
+                    onEvent = { event ->
+                        Log.i(VIRTUSIZE_BUTTON_TAG, event.name)
+                    },
+                    onError = { error ->
+                        Log.e(VIRTUSIZE_BUTTON_TAG, error.message)
+                    },
+                )
+
+                Spacer(modifier = Modifier.height(16.dp))
+
+                VirtusizeInPageStandard(
+                    product = product,
+                    modifier = Modifier.padding(horizontal = 16.dp),
+                    backgroundColor = VirtusizeColors.Black,
+                    onEvent = { event ->
+                        Log.i(VIRTUSIZE_INPAGE_STANDARD_TAG, event.name)
+                    },
+                    onError = { error ->
+                        Log.e(VIRTUSIZE_INPAGE_STANDARD_TAG, error.message)
+                    },
+                )
+
+                Spacer(modifier = Modifier.height(16.dp))
+                VirtusizeInPageMini(
+                    product = product,
+                    modifier = Modifier.padding(horizontal = 16.dp),
+                    backgroundColor = VirtusizeColors.Teal,
+                    onEvent = { event ->
+                        Log.i(VIRTUSIZE_INPAGE_MINI_TAG, event.name)
+                    },
+                    onError = { error ->
+                        Log.e(VIRTUSIZE_INPAGE_MINI_TAG, error.message)
+                    },
+                )
+            }
         }
     }
 }

--- a/virtusize/src/main/java/com/virtusize/android/compose/ui/VirtusizeComposeViewModel.kt
+++ b/virtusize/src/main/java/com/virtusize/android/compose/ui/VirtusizeComposeViewModel.kt
@@ -65,9 +65,10 @@ internal class VirtusizeComposeViewModel : ViewModel() {
     fun load(
         product: VirtusizeProduct,
         virtusizeView: VirtusizeView,
+        force: Boolean = false,
     ) {
         virtusize.setupVirtusizeView(product = product, virtusizeView = virtusizeView)
-        if (lastLoadedProductId != product.externalId) {
+        if (force || lastLoadedProductId != product.externalId) {
             lastLoadedProductId = product.externalId
             virtusize.load(product)
         }

--- a/virtusize/src/main/java/com/virtusize/android/compose/ui/VirtusizeInPageMini.kt
+++ b/virtusize/src/main/java/com/virtusize/android/compose/ui/VirtusizeInPageMini.kt
@@ -45,9 +45,12 @@ fun VirtusizeInPageMini(
 
     VirtusizeInPageMini(
         modifier = modifier,
+        create = { virtusizeInPageMini ->
+            viewModel.load(product = product, virtusizeView = virtusizeInPageMini, force = true)
+        },
         update = { virtusizeInPageMini ->
             viewRef.value = virtusizeInPageMini
-            viewModel.load(product = product, virtusizeView = virtusizeInPageMini)
+            viewModel.load(product = product, virtusizeView = virtusizeInPageMini, force = false)
         },
     )
 
@@ -72,11 +75,12 @@ fun VirtusizeInPageMini(
 @Composable
 private fun VirtusizeInPageMini(
     modifier: Modifier = Modifier,
+    create: (VirtusizeInPageMini) -> Unit = {},
     update: (VirtusizeInPageMini) -> Unit = NoOpUpdate,
 ) {
     AndroidView(
         modifier = modifier,
-        factory = { context -> VirtusizeInPageMini(context) },
+        factory = { context -> VirtusizeInPageMini(context).also { create(it) } },
         update = update,
         onRelease = { virtusizeView ->
             Virtusize.getInstanceOrNull()?.cleanupVirtusizeView(virtusizeView)

--- a/virtusize/src/main/java/com/virtusize/android/compose/ui/VirtusizeInpPageStandard.kt
+++ b/virtusize/src/main/java/com/virtusize/android/compose/ui/VirtusizeInpPageStandard.kt
@@ -46,9 +46,12 @@ fun VirtusizeInPageStandard(
 
     VirtusizeInPageStandard(
         modifier = modifier,
+        create = { virtusizeInPageStandard ->
+            viewModel.load(product = product, virtusizeView = virtusizeInPageStandard, force = true)
+        },
         update = { virtusizeInPageStandard ->
             viewRef.value = virtusizeInPageStandard
-            viewModel.load(product = product, virtusizeView = virtusizeInPageStandard)
+            viewModel.load(product = product, virtusizeView = virtusizeInPageStandard, force = false)
         },
     )
 
@@ -73,6 +76,7 @@ fun VirtusizeInPageStandard(
 @Composable
 private fun VirtusizeInPageStandard(
     modifier: Modifier = Modifier,
+    create: (VirtusizeInPageStandard) -> Unit = {},
     update: (VirtusizeInPageStandard) -> Unit = NoOpUpdate,
 ) {
     AndroidView(
@@ -81,7 +85,7 @@ private fun VirtusizeInPageStandard(
             VirtusizeInPageStandard(context).apply {
                 horizontalMargin = 0
                 clipChildren = false
-            }
+            }.also { create(it) }
         },
         update = update,
         onRelease = { virtusizeView ->


### PR DESCRIPTION
## ⬅️ As Is

Aleksandr fix request:
Okay, I think I figured out the cause of the issues we have. It seems like the issues occur when Virtusize composable leaves, and then enters the composition again. And since its ViewModel has always been alive, it does not call load when VIrtusize reenters the composition (because externalId is the same).

## ➡️ To Be

Widget updates as expected

## ☑️ Checklist

- [x] Useless comments and/or `Log.d` etc are **removed**
- [x] Unit test are **covered**
- [x] Code has been **deployed and tested** on STG
- [x] ClickUp ticket status has been **updated** to `production`
- [ ] Update CHANGELOG.md with the new changes
