### PR TITLE
NSDK-423 - app crash on **externalProductId** is nil

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
-### Changes:
+### Changes
+- Fix: crash on externalProductId nil
+- Fix: Sentry logger for Flutter
+
+### 2.12.22
 - Fix: Align iOS and Android willFit parameter for recommended text
 - Feature: Added Sentry logger
 - Feature: Web view logs handler

--- a/virtusize/src/main/AndroidManifest.xml
+++ b/virtusize/src/main/AndroidManifest.xml
@@ -5,27 +5,14 @@
 
     <application>
 
+        <meta-data
+            android:name="io.sentry.auto-init"
+            android:value="false" />
+
         <activity
             android:theme="@style/Theme.AppCompat.Light.NoActionBar"
             android:name=".ui.VirtusizeWebViewActivity" />
 
-        <!-- Required: set your sentry.io project identifier (DSN) -->
-        <meta-data
-            android:name="io.sentry.dsn"
-            android:value="https://fc419e92ef1a49b9cef57d1c6f207e75@o903.ingest.us.sentry.io/4510877744562176"
-            />
-        <!-- Add data like request headers, user ip address and device name, see https://docs.sentry.io/platforms/android/data-management/data-collected/ for more info -->
-        <meta-data
-            android:name="io.sentry.send-default-pii"
-            android:value="true"
-            />
-        <!-- Enable Sentry structured Logs feature (requires sentry-android >= 8.0.0) -->
-        <meta-data
-            android:name="io.sentry.logs.enabled"
-            android:value="true" />
-        <meta-data
-            android:name="io.sentry.metrics.enabled"
-            android:value="true" />
     </application>
 
 </manifest>

--- a/virtusize/src/main/java/com/virtusize/android/Virtusize.kt
+++ b/virtusize/src/main/java/com/virtusize/android/Virtusize.kt
@@ -32,6 +32,7 @@ interface Virtusize {
         ) = if (!Companion::instance.isInitialized) {
             synchronized(this) {
                 if (!Companion::instance.isInitialized) {
+                    VirtusizeSentryTracker.initSentry(context)
                     VirtusizeImpl(context = context, params = params).also { instance = it }
                 } else {
                     instance

--- a/virtusize/src/main/java/com/virtusize/android/VirtusizeSentryTracker.kt
+++ b/virtusize/src/main/java/com/virtusize/android/VirtusizeSentryTracker.kt
@@ -1,14 +1,16 @@
 package com.virtusize.android
 
+import android.content.Context
 import com.virtusize.android.data.local.VirtusizeOrder
 import io.sentry.Sentry
+import io.sentry.android.core.SentryAndroid
 import java.util.UUID
 
 /**
  * Utility for Sentry metrics and structured logs tracking in the Virtusize SDK.
  *
  * Requires Sentry Android SDK >= 8.0.0.
- * Configured via AndroidManifest.xml meta-data (DSN, logs, traces sample rate, environment).
+ * Initialized programmatically via initSentry(context).
  */
 internal object VirtusizeSentryTracker {
     // MARK: - Session Management
@@ -16,7 +18,13 @@ internal object VirtusizeSentryTracker {
     /** The current active session ID, set by Virtusize.load. */
     var currentSessionId: String = ""
 
-    init {
+    fun initSentry(context: Context) {
+        SentryAndroid.init(context) { options ->
+            options.dsn = "https://fc419e92ef1a49b9cef57d1c6f207e75@o903.ingest.us.sentry.io/4510877744562176"
+            options.isDebug = false
+            options.isSendDefaultPii = true
+            options.logs.isEnabled = true
+        }
         Sentry.configureScope { scope ->
             scope.setTag("sdk_version", BuildConfig.VERSION_NANE)
             scope.setTag("sdk_platform", "android")

--- a/virtusize/src/main/java/com/virtusize/android/data/local/VirtusizeParams.kt
+++ b/virtusize/src/main/java/com/virtusize/android/data/local/VirtusizeParams.kt
@@ -36,9 +36,12 @@ data class VirtusizeParams(
     internal val serviceEnvironment: Boolean,
 ) {
     /**
-     * Returns the virtusize parameter string to be passed to the JavaScript function vsParamsFromSDK
+     * Returns the virtusize parameter string to be passed to the JavaScript function vsParamsFromSDK,
+     * or null if required params (apiKey, product externalId) are missing.
      */
-    internal fun vsParamsString(product: VirtusizeProduct): String {
+    internal fun vsParamsString(product: VirtusizeProduct): String? {
+        val apiKey = apiKey ?: return null
+        if (product.externalId.isEmpty()) return null
         val prefs = SharedPreferencesHelper.getInstance(context)
         val sessionData = prefs.getSessionData()
         val bid = prefs.getBrowserId()

--- a/virtusize/src/main/java/com/virtusize/android/flutter/VirtusizeFlutter.kt
+++ b/virtusize/src/main/java/com/virtusize/android/flutter/VirtusizeFlutter.kt
@@ -36,6 +36,7 @@ interface VirtusizeFlutter {
         ) = if (!Companion::instance.isInitialized) {
             synchronized(this) {
                 if (!Companion::instance.isInitialized) {
+                    VirtusizeSentryTracker.initSentry(context)
                     VirtusizeSentryTracker.setSDKPlatform("flutter-android")
                     VirtusizeFlutterImpl(
                         context = context,

--- a/virtusize/src/main/java/com/virtusize/android/ui/VirtusizeWebViewFragment.kt
+++ b/virtusize/src/main/java/com/virtusize/android/ui/VirtusizeWebViewFragment.kt
@@ -128,7 +128,9 @@ class VirtusizeWebViewFragment : DialogFragment() {
                 ) {
                     if (url != null && url.contains(virtusizeWebAppUrl)) {
                         Log.d("[Aoyama-mobile]", "Evaluating vsParamsFromSDKScript: $vsParamsFromSDKScript")
-                        binding.webView.evaluateJavascript(vsParamsFromSDKScript, null)
+                        if (vsParamsFromSDKScript.isNotBlank()) {
+                            binding.webView.evaluateJavascript(vsParamsFromSDKScript, null)
+                        }
                         binding.webView.evaluateJavascript(
                             "javascript:window.virtusizeSNSEnabled = $showSNSButtons;",
                             null,

--- a/virtusize/src/main/java/com/virtusize/android/util/VirtusizeUtils.kt
+++ b/virtusize/src/main/java/com/virtusize/android/util/VirtusizeUtils.kt
@@ -126,10 +126,12 @@ internal object VirtusizeUtils {
     ): Bundle =
         Bundle().apply {
             virtusizeParams?.let { params ->
-                putString(
-                    Constants.VIRTUSIZE_PARAMS_SCRIPT_KEY,
-                    "javascript:vsParamsFromSDK(${params.vsParamsString(product)})",
-                )
+                params.vsParamsString(product)?.let { paramsString ->
+                    putString(
+                        Constants.VIRTUSIZE_PARAMS_SCRIPT_KEY,
+                        "javascript:vsParamsFromSDK($paramsString)",
+                    )
+                }
                 putBoolean(Constants.VIRTUSIZE_SHOW_SNS_BUTTONS, virtusizeParams.showSNSButtons)
             }
             putParcelable(Constants.VIRTUSIZE_PRODUCT_KEY, product)


### PR DESCRIPTION
- Fix: crash on externalProductId nil
- Fix: Sentry logger for Flutter 

## 🔗 Related Links

- [ ] [ClickUp](https://app.clickup.com/t/3702259/NSDK-423)

## ⬅️ As Is

Application crash on open webview in **externalProductId** is nil condition 

## ➡️ To Be

Added a condition check and break excution on **externalProductId** is nil

## ☑️ Checklist

- [ ] Useless comments and/or `print` etc are **removed**
- [ ] Unit test are **covered**
- [ ] Code has been **deployed and tested** on STG
- [ ] ClickUp ticket status has been **updated** to `production`
- [ ] Update CHANGELOG.md with the new changes